### PR TITLE
Add basic news scraper for San Francisco

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.py]
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env/
 __pycache__/
 .DS_Store
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+beautifulsoup4==4.9.0
 certifi==2019.11.28
 chardet==3.0.4
 click==7.1.1
 Flask==1.1.1
+html5lib==1.0.1
 idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.1

--- a/run_scraper_news.sh
+++ b/run_scraper_news.sh
@@ -1,0 +1,2 @@
+source env/bin/activate;
+python3 scraper_news.py;

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from bs4 import BeautifulSoup
+import json
+import re
+import requests
+from urllib.parse import urljoin
+
+
+HEADING_PATTERN = re.compile(r'h\d')
+ISO_DATETIME_PATTERN = re.compile(r'^\d{4}-\d\d-\d\d(T|\s)\d\d:\d\d:\d\d(\.\d+)?(Z|\d{4}|\d\d:\d\d)$')
+
+
+def get_base_url(soup, url):
+    base = soup.find('base')
+    if base and base['href']:
+        return urljoin(url, base['href'].strip())
+    else:
+        return url
+
+
+class NewsScraper:
+    START_URL = None
+
+    def scrape(self):
+        # TODO: we may want to iterate through multiple pages in the future
+        response = requests.get(self.START_URL)
+        response.raise_for_status()
+        news = self.parse_page(response.text, self.START_URL)
+        return news
+
+    def parse_page(self, html, url):
+        raise NotImplementedError()
+
+
+class SanFranciscoNews(NewsScraper):
+    START_URL = 'https://sf.gov/news/topics/794'
+
+    def parse_page(self, html, url):
+        soup = BeautifulSoup(html, 'html5lib')
+        base_url = get_base_url(soup, url)
+        news = []
+        articles = soup.main.find_all('article')
+        for index, article in enumerate(articles):
+            title_link = article.find(HEADING_PATTERN).find('a')
+
+            url = title_link['href']
+            if not url:
+                raise ValueError(f'Not URL found for article {index}')
+            else:
+                url = urljoin(base_url, url)
+
+            title = title_link.get_text(strip=True)
+            if not title:
+                raise ValueError(f'No title content found for article {index}')
+
+            date = article.find('time')['datetime']
+            if not ISO_DATETIME_PATTERN.match(date):
+                raise ValueError(f'Article {index} date is not in ISO 8601'
+                                 f'format: "{date}"')
+
+            news.append({
+                'url': url,
+                'text': title,
+                'date': date
+            })
+
+        return news
+
+
+def main():
+    scraper = SanFranciscoNews()
+    news = scraper.scrape()
+    news_data = {'newsItems': news}
+    print(json.dumps(news_data, indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It turns out San Francisco (and all the other bay area counties I've checked so far) don't actually have RSS or other feeds for news, so we need to start scraping these sites if we want to show news across all the counties. This commit adds a really basic scraper that reproduces the current data format used by the site and scrapes San Francisco's coronavirus news page (the site only shows San Francisco right now, so we aren't losing anything here).

You can run it with `sh run_scraper_news.sh` or `python scraper_news.py`.

I didn’t add any tests since there’s no existing structure for them, but let me know if you want me to pull in pytest or something.