### PR TITLE
Restructure news scrapers into `news` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
 __pycache__/
+.mypy_cache/
 .DS_Store
 .vscode

--- a/news/__init__.py
+++ b/news/__init__.py
@@ -1,0 +1,14 @@
+from .san_francisco import SanFranciscoNews
+
+
+scrapers = {
+    'alameda': None,
+    'contra_costa': None,
+    'marin': None,
+    'napa': None,
+    'san_francisco': SanFranciscoNews,
+    'san_mateo': None,
+    'santa_clara': None,
+    'solano': None,
+    'sonoma': None,
+}

--- a/news/__init__.py
+++ b/news/__init__.py
@@ -1,8 +1,10 @@
+from typing import Dict, Type
 from .alameda import AlamedaNews
+from .base import NewsScraper
 from .san_francisco import SanFranciscoNews
 
 
-scrapers = {
+scrapers: Dict[str, Type[NewsScraper]] = {
     'alameda': AlamedaNews,
     # 'contra_costa': None,
     # 'marin': None,

--- a/news/__init__.py
+++ b/news/__init__.py
@@ -1,8 +1,9 @@
+from .alameda import AlamedaNews
 from .san_francisco import SanFranciscoNews
 
 
 scrapers = {
-    # 'alameda': None,
+    'alameda': AlamedaNews,
     # 'contra_costa': None,
     # 'marin': None,
     # 'napa': None,

--- a/news/__init__.py
+++ b/news/__init__.py
@@ -2,13 +2,13 @@ from .san_francisco import SanFranciscoNews
 
 
 scrapers = {
-    'alameda': None,
-    'contra_costa': None,
-    'marin': None,
-    'napa': None,
+    # 'alameda': None,
+    # 'contra_costa': None,
+    # 'marin': None,
+    # 'napa': None,
     'san_francisco': SanFranciscoNews,
-    'san_mateo': None,
-    'santa_clara': None,
-    'solano': None,
-    'sonoma': None,
+    # 'san_mateo': None,
+    # 'santa_clara': None,
+    # 'solano': None,
+    # 'sonoma': None,
 }

--- a/news/alameda.py
+++ b/news/alameda.py
@@ -2,5 +2,5 @@ from .base import NewsScraper
 
 
 class AlamedaNews(NewsScraper):
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError("The Alameda county news scraper hasn't been written yet!")

--- a/news/alameda.py
+++ b/news/alameda.py
@@ -1,0 +1,6 @@
+from .base import NewsScraper
+
+
+class AlamedaNews(NewsScraper):
+    def __init__(self):
+        raise NotImplementedError("The Alameda county news scraper hasn't been written yet!")

--- a/news/base.py
+++ b/news/base.py
@@ -1,0 +1,15 @@
+import requests
+
+
+class NewsScraper:
+    START_URL = None
+
+    def scrape(self):
+        # TODO: we may want to iterate through multiple pages in the future
+        response = requests.get(self.START_URL)
+        response.raise_for_status()
+        news = self.parse_page(response.text, self.START_URL)
+        return news
+
+    def parse_page(self, html, url):
+        raise NotImplementedError()

--- a/news/base.py
+++ b/news/base.py
@@ -1,4 +1,5 @@
 import requests
+from typing import List
 
 
 class NewsScraper:
@@ -18,9 +19,9 @@ class NewsScraper:
     of news items given some HTML.
     """
 
-    START_URL = None
+    START_URL = ''
 
-    def scrape(self):
+    def scrape(self) -> List[dict]:
         """
         Create and return a news feed.
 
@@ -42,5 +43,5 @@ class NewsScraper:
         news = self.parse_page(response.text, self.START_URL)
         return news
 
-    def parse_page(self, html, url):
+    def parse_page(self, html: str, url: str) -> List[dict]:
         raise NotImplementedError()

--- a/news/base.py
+++ b/news/base.py
@@ -2,9 +2,40 @@ import requests
 
 
 class NewsScraper:
+    """
+    Base class for news scrapers. Common scraping/news feed functionality used
+    across multiple counties should be implemented here. This class should be
+    inherited and never used directly.
+
+    To run a scraper, first instantiate it, then call `scrape()`:
+    >>> class SomeCounty(NewsScraper):
+    >>>     ...
+    >>> scraper = SomeCounty()
+    >>> news_feed = scraper.scrape()
+
+    Classes inheriting from this should set ``START_URL`` to the URL from which
+    scraping should start, then implement `parse_page()`, which returns a list
+    of news items given some HTML.
+    """
+
     START_URL = None
 
     def scrape(self):
+        """
+        Create and return a news feed.
+
+        Returns
+        -------
+        list of dict
+
+        Examples
+        --------
+        >>> scraper = SanFranciscoNews()
+        >>> scraper.scrape()
+        [{'url': 'https://sf.gov/news/expansion-coronavirus-testing-all-essential-workers-sf',
+          'text': 'Expansion of coronavirus testing for all essential workers in SF',
+          'date': '2020-04-23T04:11:56Z'}]
+        """
         # TODO: we may want to iterate through multiple pages in the future
         response = requests.get(self.START_URL)
         response.raise_for_status()

--- a/news/san_francisco.py
+++ b/news/san_francisco.py
@@ -1,0 +1,39 @@
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+from .base import NewsScraper
+from .utils import get_base_url, HEADING_PATTERN, ISO_DATETIME_PATTERN
+
+
+class SanFranciscoNews(NewsScraper):
+    START_URL = 'https://sf.gov/news/topics/794'
+
+    def parse_page(self, html, url):
+        soup = BeautifulSoup(html, 'html5lib')
+        base_url = get_base_url(soup, url)
+        news = []
+        articles = soup.main.find_all('article')
+        for index, article in enumerate(articles):
+            title_link = article.find(HEADING_PATTERN).find('a')
+
+            url = title_link['href']
+            if not url:
+                raise ValueError(f'Not URL found for article {index}')
+            else:
+                url = urljoin(base_url, url)
+
+            title = title_link.get_text(strip=True)
+            if not title:
+                raise ValueError(f'No title content found for article {index}')
+
+            date = article.find('time')['datetime']
+            if not ISO_DATETIME_PATTERN.match(date):
+                raise ValueError(f'Article {index} date is not in ISO 8601'
+                                 f'format: "{date}"')
+
+            news.append({
+                'url': url,
+                'text': title,
+                'date': date
+            })
+
+        return news

--- a/news/san_francisco.py
+++ b/news/san_francisco.py
@@ -1,4 +1,5 @@
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup  # type: ignore
+from typing import List
 from urllib.parse import urljoin
 from .base import NewsScraper
 from .utils import get_base_url, HEADING_PATTERN, ISO_DATETIME_PATTERN
@@ -27,7 +28,7 @@ class SanFranciscoNews(NewsScraper):
 
     START_URL = 'https://sf.gov/news/topics/794'
 
-    def parse_page(self, html, url):
+    def parse_page(self, html: str, url: str) -> List[dict]:
         soup = BeautifulSoup(html, 'html5lib')
         base_url = get_base_url(soup, url)
         news = []

--- a/news/san_francisco.py
+++ b/news/san_francisco.py
@@ -5,6 +5,26 @@ from .utils import get_base_url, HEADING_PATTERN, ISO_DATETIME_PATTERN
 
 
 class SanFranciscoNews(NewsScraper):
+    """
+    Scrape official county COVID-related news from San Francisco. The county's
+    official site does not have RSS, so this scrapes HTML.
+
+    City folks have suggested we may also want to consider adding items from at
+    these sources in the future:
+    - Mayor's press releases: https://sfmayor.org/news (which has RSS)
+    - DPH: https://www.sfdph.org/dph/comupg/aboutdph/newsMedia/default.asp
+    - SF General Hospital: https://zuckerbergsanfranciscogeneral.org/about-us/news/
+    - Laguna Honda Hospital: https://lagunahonda.org/press-releases
+
+    Examples
+    --------
+    >>> scraper = SanFranciscoNews()
+    >>> scraper.scrape()
+    [{'url': 'https://sf.gov/news/expansion-coronavirus-testing-all-essential-workers-sf',
+      'text': 'Expansion of coronavirus testing for all essential workers in SF',
+      'date': '2020-04-23T04:11:56Z'}]
+    """
+
     START_URL = 'https://sf.gov/news/topics/794'
 
     def parse_page(self, html, url):

--- a/news/utils.py
+++ b/news/utils.py
@@ -7,6 +7,22 @@ ISO_DATETIME_PATTERN = re.compile(r'^\d{4}-\d\d-\d\d(T|\s)\d\d:\d\d:\d\d(\.\d+)?
 
 
 def get_base_url(soup, url):
+    """
+    Get the base URL for a BeautifulSoup page, given the URL it was loaded
+    from. This can then be used with ``urllib.parse.urljoin`` to make sure any
+    link or resource URL on the page to get the absolute URL it refers to.
+
+    Parameters
+    ----------
+    soup : BeautifulSoup
+        A BeautifulSoup-parsed web page.
+    url : str
+        The URL that the web page was loaded from.
+
+    Returns
+    -------
+    str
+    """
     base = soup.find('base')
     if base and base['href']:
         return urljoin(url, base['href'].strip())

--- a/news/utils.py
+++ b/news/utils.py
@@ -1,0 +1,14 @@
+import re
+from urllib.parse import urljoin
+
+
+HEADING_PATTERN = re.compile(r'h\d')
+ISO_DATETIME_PATTERN = re.compile(r'^\d{4}-\d\d-\d\d(T|\s)\d\d:\d\d:\d\d(\.\d+)?(Z|\d{4}|\d\d:\d\d)$')
+
+
+def get_base_url(soup, url):
+    base = soup.find('base')
+    if base and base['href']:
+        return urljoin(url, base['href'].strip())
+    else:
+        return url

--- a/news/utils.py
+++ b/news/utils.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup  # type: ignore
 import re
 from urllib.parse import urljoin
 
@@ -6,7 +7,7 @@ HEADING_PATTERN = re.compile(r'h\d')
 ISO_DATETIME_PATTERN = re.compile(r'^\d{4}-\d\d-\d\d(T|\s)\d\d:\d\d:\d\d(\.\d+)?(Z|\d{4}|\d\d:\d\d)$')
 
 
-def get_base_url(soup, url):
+def get_base_url(soup: BeautifulSoup, url: str) -> str:
     """
     Get the base URL for a BeautifulSoup page, given the URL it was loaded
     from. This can then be used with ``urllib.parse.urljoin`` to make sure any

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -1,77 +1,35 @@
 #!/usr/bin/env python3
-from bs4 import BeautifulSoup
 import json
-import re
-import requests
-from urllib.parse import urljoin
+import news
+import sys
 
 
-HEADING_PATTERN = re.compile(r'h\d')
-ISO_DATETIME_PATTERN = re.compile(r'^\d{4}-\d\d-\d\d(T|\s)\d\d:\d\d:\d\d(\.\d+)?(Z|\d{4}|\d\d:\d\d)$')
-
-
-def get_base_url(soup, url):
-    base = soup.find('base')
-    if base and base['href']:
-        return urljoin(url, base['href'].strip())
-    else:
-        return url
-
-
-class NewsScraper:
-    START_URL = None
-
-    def scrape(self):
-        # TODO: we may want to iterate through multiple pages in the future
-        response = requests.get(self.START_URL)
-        response.raise_for_status()
-        news = self.parse_page(response.text, self.START_URL)
-        return news
-
-    def parse_page(self, html, url):
-        raise NotImplementedError()
-
-
-class SanFranciscoNews(NewsScraper):
-    START_URL = 'https://sf.gov/news/topics/794'
-
-    def parse_page(self, html, url):
-        soup = BeautifulSoup(html, 'html5lib')
-        base_url = get_base_url(soup, url)
-        news = []
-        articles = soup.main.find_all('article')
-        for index, article in enumerate(articles):
-            title_link = article.find(HEADING_PATTERN).find('a')
-
-            url = title_link['href']
-            if not url:
-                raise ValueError(f'Not URL found for article {index}')
-            else:
-                url = urljoin(base_url, url)
-
-            title = title_link.get_text(strip=True)
-            if not title:
-                raise ValueError(f'No title content found for article {index}')
-
-            date = article.find('time')['datetime']
-            if not ISO_DATETIME_PATTERN.match(date):
-                raise ValueError(f'Article {index} date is not in ISO 8601'
-                                 f'format: "{date}"')
-
-            news.append({
-                'url': url,
-                'text': title,
-                'date': date
-            })
-
-        return news
+def message(text):
+    print(text, file=sys.stderr)
 
 
 def main():
-    scraper = SanFranciscoNews()
-    news = scraper.scrape()
-    news_data = {'newsItems': news}
-    print(json.dumps(news_data, indent=2))
+    # TODO: use Click or argparse so we can manage more complex options
+    counties = sys.argv[1:]
+
+    # Validate args before starting to scrape
+    for county in counties:
+        if county not in news.scrapers:
+            message(f'Unknown county: "{county}"')
+            sys.exit(1)
+        elif news.scrapers[county] is None:
+            message(f'Scraper for {county} has not yet been written')
+            sys.exit(1)
+
+    if len(counties) == 0:
+        counties = ['san_francisco']
+
+    # Do the work!
+    for county in counties:
+        scraper = news.scrapers[county]()
+        feed_items = scraper.scrape()
+        feed = {'newsItems': feed_items}
+        print(json.dumps(feed, indent=2))
 
 
 if __name__ == '__main__':

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -2,6 +2,7 @@
 import click
 import json
 import news
+from typing import Tuple
 
 
 COUNTY_NAMES = tuple(news.scrapers.keys())
@@ -11,7 +12,7 @@ COUNTY_NAMES = tuple(news.scrapers.keys())
                     f'counties: {", ".join(COUNTY_NAMES)}.')
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
-def main(counties):
+def main(counties: Tuple[str]) -> None:
     if len(counties) == 0:
         counties = ('san_francisco',)
 

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -1,28 +1,19 @@
 #!/usr/bin/env python3
+import click
 import json
 import news
-import sys
 
 
-def message(text):
-    print(text, file=sys.stderr)
+COUNTY_NAMES = tuple(news.scrapers.keys())
 
 
-def main():
-    # TODO: use Click or argparse so we can manage more complex options
-    counties = sys.argv[1:]
-
-    # Validate args before starting to scrape
-    for county in counties:
-        if county not in news.scrapers:
-            message(f'Unknown county: "{county}"')
-            sys.exit(1)
-        elif news.scrapers[county] is None:
-            message(f'Scraper for {county} has not yet been written')
-            sys.exit(1)
-
+@click.command(help='Create a news feed for one or more counties. Supported '
+                    f'counties: {", ".join(COUNTY_NAMES)}.')
+@click.argument('counties', metavar='[COUNTY]...', nargs=-1,
+                type=click.Choice(COUNTY_NAMES, case_sensitive=False))
+def main(counties):
     if len(counties) == 0:
-        counties = ['san_francisco']
+        counties = ('san_francisco',)
 
     # Do the work!
     for county in counties:


### PR DESCRIPTION
In order to make a big set of scrapers more manageable, this creates a `news` package where we can have one module per scraper (plus other support modules). The same script as before is the entry point, but you specify counties as arguments, e.g:

```sh
# Get San Francisco News
> python3 scraper_news.py san_francisco

# Get Alameda News
> python3 scraper_news.py alameda

# Get Both
> python3 scraper_news.py san_francisco alameda
```

If you don't specify any arguments it currently defaults to `san_francisco`, but in the future this will eventually be turned into a combined feed of all counties instead.

~Before merging, I want to clean up the argument parsing by using either `click` or `ArgParse`, but this should otherwise be good to go.~ *(This is done now.)*

Fixes #41.