### PR TITLE
Support json_feed, json_simple, and rss news formats

### DIFF
--- a/news/base.py
+++ b/news/base.py
@@ -1,5 +1,5 @@
 import requests
-from typing import List
+from typing import Dict, List
 from .feed import NewsFeed, NewsItem
 
 
@@ -19,8 +19,11 @@ class NewsScraper:
     scraping should start, then implement `parse_page()`, which returns a list
     of news items given some HTML.
     """
-    FEED_TITLE = ''
+    FEED_INFO: Dict = {}
     START_URL = ''
+
+    def create_feed(self) -> NewsFeed:
+        return NewsFeed(**self.FEED_INFO)
 
     def scrape(self) -> NewsFeed:
         """
@@ -38,7 +41,7 @@ class NewsScraper:
           'text': 'Expansion of coronavirus testing for all essential workers in SF',
           'date': '2020-04-23T04:11:56Z'}]
         """
-        feed = NewsFeed(title=self.FEED_TITLE)
+        feed = self.create_feed()
         # TODO: we may want to iterate through multiple pages in the future
         response = requests.get(self.START_URL)
         response.raise_for_status()

--- a/news/base.py
+++ b/news/base.py
@@ -1,5 +1,6 @@
 import requests
 from typing import List
+from .feed import NewsFeed, NewsItem
 
 
 class NewsScraper:
@@ -18,10 +19,10 @@ class NewsScraper:
     scraping should start, then implement `parse_page()`, which returns a list
     of news items given some HTML.
     """
-
+    FEED_TITLE = ''
     START_URL = ''
 
-    def scrape(self) -> List[dict]:
+    def scrape(self) -> NewsFeed:
         """
         Create and return a news feed.
 
@@ -37,11 +38,13 @@ class NewsScraper:
           'text': 'Expansion of coronavirus testing for all essential workers in SF',
           'date': '2020-04-23T04:11:56Z'}]
         """
+        feed = NewsFeed(title=self.FEED_TITLE)
         # TODO: we may want to iterate through multiple pages in the future
         response = requests.get(self.START_URL)
         response.raise_for_status()
         news = self.parse_page(response.text, self.START_URL)
-        return news
+        feed.items.extend(news)
+        return feed
 
-    def parse_page(self, html: str, url: str) -> List[dict]:
+    def parse_page(self, html: str, url: str) -> List[NewsItem]:
         raise NotImplementedError()

--- a/news/feed.py
+++ b/news/feed.py
@@ -5,8 +5,8 @@ Tools for modeling news feeds and serializing to multiple formats.
 from dataclasses import dataclass, field, fields
 from datetime import datetime
 import locale
-from lxml.builder import E
-import lxml.etree as ElementTree
+from lxml.builder import E  # type: ignore
+import lxml.etree as ElementTree  # type: ignore
 from typing import Dict, List, Optional, Any
 
 

--- a/news/feed.py
+++ b/news/feed.py
@@ -4,10 +4,13 @@ Tools for modeling news feeds and serializing to multiple formats.
 
 from dataclasses import dataclass, field, fields
 from datetime import datetime
+import locale
+from lxml.builder import E
+import lxml.etree as ElementTree
 from typing import Dict, List, Optional, Any
 
 
-def format_datetime(date_obj: datetime) -> str:
+def format_datetime_8601(date_obj: datetime) -> str:
     """
     Get an ISO 8601-formatted string for a datetime, but ensure that UTC is
     represented with the shortened 'Z' form (i.e. W3C-style).
@@ -16,6 +19,17 @@ def format_datetime(date_obj: datetime) -> str:
     if formatted.endswith('+00:00'):
         formatted = formatted[:-6] + 'Z'
     return formatted
+
+
+def format_datetime_2822(date_obj: datetime) -> str:
+    """
+    Get an RFC 2822-formatted string for a datetime.
+    """
+    old = locale.setlocale(locale.LC_ALL)
+    locale.setlocale(locale.LC_ALL, 'C')
+    date = date_obj.strftime('%a, %d %b %Y %H:%M:%S %z')
+    locale.setlocale(locale.LC_ALL, old)
+    return date
 
 
 @dataclass
@@ -35,7 +49,7 @@ class NewsItem:
         return {
             'url': self.url,
             'text': self.title,
-            'date': format_datetime(self.date_published)
+            'date': format_datetime_8601(self.date_published)
         }
 
     def format_json_feed(self) -> Dict:
@@ -47,10 +61,18 @@ class NewsItem:
             value = getattr(self, item_field.name)
             if value:
                 if isinstance(value, datetime):
-                    value = format_datetime(value)
+                    value = format_datetime_8601(value)
                 result[item_field.name] = value
 
         return result
+
+    def format_rss(self) -> ElementTree.Element:
+        return E.item(
+            E('guid', self.id),
+            E('title', self.title),
+            E('link', self.url),
+            E('pubDate', format_datetime_2822(self.date_published))
+        )
 
 
 @dataclass
@@ -66,11 +88,27 @@ class NewsFeed:
     items: List[NewsItem] = field(default_factory=list, init=False)
 
     def format_json_simple(self) -> Dict:
+        """
+        Output this news feed in a simplified JSON format. The output is a
+        JSON-serializable dict; not an actual string.
+
+        Returns
+        -------
+        dict
+        """
         return {
             'newsItems': [item.format_json_simple() for item in self.items]
         }
 
     def format_json_feed(self) -> Dict:
+        """
+        Output this news feed in JSON Feed format (https://jsonfeed.org/). The
+        output is a JSON-serializable dict; not an actual string.
+
+        Returns
+        -------
+        dict
+        """
         if not self.title:
             raise ValueError('You must specify a `title` for this feed')
 
@@ -86,3 +124,47 @@ class NewsFeed:
                 feed[item_field.name] = value
 
         return feed
+
+    # TODO: revisit whether this should really return a string -- when the XML
+    # is serialized to bytes in a file, it should ideally have an XML encoding
+    # declaration at the top, but `ElementTree.tostring` very reasonably won't
+    # output that if you're asking for a string (`encoding='unicode'`) back
+    # instead of bytes (e.g. with `encoding='utf-8'`).
+    def format_rss(self, pretty: bool = True) -> str:
+        """
+        Output this news feed in RSS 2.0 format.
+
+        Parameters
+        ----------
+        pretty
+            Whether to "pretty print" the XML so there's generally one element
+            per line, instead of shoving it all together in the most compact
+            possible representation. (Default: True)
+
+        Returns
+        -------
+        str
+            An XML string. Note this is a *string*, not bytes, so you may want
+            to add an XML encoding header (e.g.
+            `<?xml version="1.0" encoding="UTF-8"?>`) when writing to disk.
+        """
+        if not self.title:
+            raise ValueError('You must specify a `title` for this feed')
+        if not self.home_page_url:
+            raise ValueError('You must specify a `home_page_url` for this feed')
+
+        rss = E.rss(
+            E.channel(
+                E('title', self.title),
+                E('link', self.home_page_url),
+                # Description is required in RSS 2.0, but we don't always
+                # have anything useful to put there.
+                E('description', self.description or ''),
+                *(item.format_rss() for item in self.items)
+            ),
+            {'version': '2.0'}
+        )
+
+        #
+        return ElementTree.tostring(rss, encoding='unicode',
+                                    pretty_print=pretty)

--- a/news/san_francisco.py
+++ b/news/san_francisco.py
@@ -28,7 +28,11 @@ class SanFranciscoNews(NewsScraper):
       'date': '2020-04-23T04:11:56Z'}]
     """
 
-    FEED_TITLE = 'San Francisco County COVID-19 News'
+    FEED_INFO = dict(
+        title='San Francisco County COVID-19 News',
+        home_page_url='https://sf.gov/news/topics/794'
+    )
+
     START_URL = 'https://sf.gov/news/topics/794'
 
     def parse_page(self, html: str, url: str) -> List[NewsItem]:

--- a/news/san_francisco.py
+++ b/news/san_francisco.py
@@ -1,8 +1,10 @@
 from bs4 import BeautifulSoup  # type: ignore
+import dateutil.parser
 from typing import List
 from urllib.parse import urljoin
 from .base import NewsScraper
-from .utils import get_base_url, HEADING_PATTERN, ISO_DATETIME_PATTERN
+from .feed import NewsItem
+from .utils import get_base_url, HEADING_PATTERN
 
 
 class SanFranciscoNews(NewsScraper):
@@ -26,9 +28,10 @@ class SanFranciscoNews(NewsScraper):
       'date': '2020-04-23T04:11:56Z'}]
     """
 
+    FEED_TITLE = 'San Francisco County COVID-19 News'
     START_URL = 'https://sf.gov/news/topics/794'
 
-    def parse_page(self, html: str, url: str) -> List[dict]:
+    def parse_page(self, html: str, url: str) -> List[NewsItem]:
         soup = BeautifulSoup(html, 'html5lib')
         base_url = get_base_url(soup, url)
         news = []
@@ -46,15 +49,14 @@ class SanFranciscoNews(NewsScraper):
             if not title:
                 raise ValueError(f'No title content found for article {index}')
 
-            date = article.find('time')['datetime']
-            if not ISO_DATETIME_PATTERN.match(date):
+            date_string = article.find('time')['datetime']
+            try:
+                date = dateutil.parser.parse(date_string)
+            except ValueError:
                 raise ValueError(f'Article {index} date is not in ISO 8601'
-                                 f'format: "{date}"')
+                                 f'format: "{date_string}"')
 
-            news.append({
-                'url': url,
-                'text': title,
-                'date': date
-            })
+            news.append(NewsItem(id=url, url=url, title=title,
+                                 date_published=date))
 
         return news

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ html5lib==1.0.1
 idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.1
+lxml==4.5.0
 MarkupSafe==1.1.1
 python-dateutil==2.8.1
 requests==2.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.1
 MarkupSafe==1.1.1
+python-dateutil==2.8.1
 requests==2.23.0
 urllib3==1.25.8
 Werkzeug==1.0.0

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -12,16 +12,22 @@ COUNTY_NAMES = tuple(news.scrapers.keys())
                     f'counties: {", ".join(COUNTY_NAMES)}.')
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
-def main(counties: Tuple[str]) -> None:
+@click.option('--format', default='json_simple',
+              type=click.Choice(('json_feed', 'json_simple')))
+def main(counties: Tuple[str], format: str) -> None:
     if len(counties) == 0:
         counties = ('san_francisco',)
 
     # Do the work!
     for county in counties:
         scraper = news.scrapers[county]()
-        feed_items = scraper.scrape()
-        feed = {'newsItems': feed_items}
-        print(json.dumps(feed, indent=2))
+        feed = scraper.scrape()
+
+        if format == 'json_simple':
+            data = feed.format_json_simple()
+        else:
+            data = feed.format_json_feed()
+        print(json.dumps(data, indent=2))
 
 
 if __name__ == '__main__':

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -2,6 +2,7 @@
 import click
 import json
 import news
+from pathlib import Path
 from typing import Tuple
 
 
@@ -13,7 +14,7 @@ COUNTY_NAMES = tuple(news.scrapers.keys())
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
 @click.option('--format', default='json_simple',
-              type=click.Choice(('json_feed', 'json_simple')))
+              type=click.Choice(('json_feed', 'json_simple', 'rss')))
 def main(counties: Tuple[str], format: str) -> None:
     if len(counties) == 0:
         counties = ('san_francisco',)
@@ -24,10 +25,13 @@ def main(counties: Tuple[str], format: str) -> None:
         feed = scraper.scrape()
 
         if format == 'json_simple':
-            data = feed.format_json_simple()
+            data = json.dumps(feed.format_json_simple(), indent=2)
+        elif format == 'json_feed':
+            data = json.dumps(feed.format_json_feed(), indent=2)
         else:
-            data = feed.format_json_feed()
-        print(json.dumps(data, indent=2))
+            data = feed.format_rss()
+
+        print(data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
You can now specify the output format for the news scraper with the `--format` option, which can be:
- `json_simple` (default) the current format
- `json_feed` the JSONFeed standard (https://jsonfeed.org/version/1)
- `rss` for RSS 2.0

Eventually, we'll switch `json_feed` to be the default, but for now we need to not break existing automation.

This uses dataclasses for some of its work, which are new in Python 3.7. I think that’s our minimum version, so this should be OK. (Is that right, @ldtcooper?)

You can also specify more than one format, and specify an output directory. That way, a command like this:

```sh
$ python scraper_news.py san_francisco alameda --format json_feed --format rss --output feed_data
```

Can write out 4 files, which would be a pain to deal with on STDOUT:
- `feed_data/san_francisco.json`
- `feed_data/san_francisco.rss`
- `feed_data/alameda.json`
- `feed_data/alameda.rss`

Fixes #40, fixes #42.