### PR TITLE
Add more strict configuration for Mypy

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,11 @@
 from flask import Flask
 from scraper import pipeline
+from typing import Dict
+
 app = Flask(__name__)
 
 @app.route('/scrape')
-def scrape():
+def scrape() -> Dict[str, Dict]:
     bay_area_counties = [
         'Solano County, California, United States',
         'Alameda County, California, United States',

--- a/data_scrapers/san_francisco_county.py
+++ b/data_scrapers/san_francisco_county.py
@@ -3,14 +3,14 @@ import requests
 import json
 from typing import Dict
 
-# API endpoints 
+# API endpoints
 age_gender_url = 'https://data.sfgov.org/resource/sunc-2t3k.json'
 race_ethnicity_url = 'https://data.sfgov.org/resource/vqqm-nsqg.json'
 transmission_url = 'https://data.sfgov.org/resource/tvq9-ec9w.json'
 hospitalizations_url = 'https://data.sfgov.org/resource/nxjg-bhem.json'
 tests_url = 'https://data.sfgov.org/resource/nfpa-mg4g.json'
 
-def get_json(url, query=''):
+def get_json(url: str, query: str = '') -> Dict:
     """
     Fetches data from url with optional query in JSON format
     and parses it into a dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[mypy]
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True
+no_implicit_reexport = True
+# Strict mode settings we do *not* use:
+# disallow_any_generics = True
+# warn_return_any = True
+# strict_equality = True


### PR DESCRIPTION
Per a discussion in Slack, we should be a little bit more strict about requiring and checking type annotations. This adds a config file for Mypy and specifies a configuration that is more strict. It should help us be a little better about our types.

This required some updates to existing files, and will probably require changes to any in-progress PRs, so those will need to be rebased or updated once this lands.