### PR TITLE
Clean up language and date issues in Contra Costa News

### DIFF
--- a/covid19_sfbayarea/news/contra_costa.py
+++ b/covid19_sfbayarea/news/contra_costa.py
@@ -34,7 +34,14 @@ MONTH_HEADING_PATTERN = re.compile(
 )
 
 # The text of a news item is formatted roughly as "title - date".
-ARTICLE_TITLE_PATTERN = re.compile(r'^\s*(.*?)\s*-\s*(\d+/\d+/\d+)\s*$')
+ARTICLE_TITLE_PATTERN = re.compile(r'''
+    ^\s*
+    (.*?)             # Title is everything up to...
+    (?:\s*\|\s*\w+)?  # An optional `| <language>` alternate language link
+    \s*-\s*           # A `-` separator
+    (\d+/\d+/\d+)     # The date in mm/dd/yyyy format
+    \s*$
+''', re.VERBOSE)
 
 
 class ContraCostaNews(NewsScraper):

--- a/covid19_sfbayarea/news/utils.py
+++ b/covid19_sfbayarea/news/utils.py
@@ -114,6 +114,10 @@ def parse_datetime(date_string: str, timezone: Optional[tzinfo] = PACIFIC_TIME) 
     the `timezone` argument to set the timezone to use if none was specified in
     the parsed string.
     """
+    # Handle dumb typos that might be in the dates on the page :(
+    if date_string.endswith('/202'):
+        date_string += '0'
+
     date = dateutil.parser.parse(date_string)
     if date.tzinfo is None:
         date = date.replace(tzinfo=timezone)


### PR DESCRIPTION
I noticed a couple issues in the [Contra Costa news scraper's updates](https://github.com/sfbrigade/stop-covid19-sfbayarea/pull/186/files) today:

1. Some titles had “| Spanish” at the end because some news items have alternate language versions, and we weren’t pulling those out from the title. (The links were still fine.)

2. Some dates on the page have typos that caused them to get parsed poorly. 😞 

This fixes both of those.