### PR TITLE
Ensure reliable order for items in news feeds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - data-covid-19-sfbayarea-{{ arch }}-
+            - data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - data-covid-19-sfbayarea-v1-{{ arch }}-
 
       - run:
           name: Install Dependencies
           command: ./install.sh
 
       - save_cache:
-          key: data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - env
 
@@ -43,15 +43,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - data-covid-19-sfbayarea-{{ arch }}-
+            - data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - data-covid-19-sfbayarea-v1-{{ arch }}-
 
       - run:
           name: Install Dependencies
           command: ./install.sh
 
       - save_cache:
-          key: data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - env
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,3 +65,4 @@ workflows:
   build:
     jobs:
       - lint
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
       - run:
           name: Install Dependencies
-          command: sh install.sh
+          command: ./install.sh
 
       - save_cache:
           key: data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
@@ -48,7 +48,7 @@ jobs:
 
       - run:
           name: Install Dependencies
-          command: sh install.sh
+          command: ./install.sh
 
       - save_cache:
           key: data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,31 @@ jobs:
             . env/bin/activate
             mypy .
 
+  test:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - data-covid-19-sfbayarea-{{ arch }}-
+
+      - run:
+          name: Install Dependencies
+          command: sh install.sh
+
+      - save_cache:
+          key: data-covid-19-sfbayarea-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          paths:
+            - env
+
+      - run:
+          name: Run Tests
+          command: |
+            . env/bin/activate
+            python -m pytest -v .
+
 workflows:
   build:
     jobs:

--- a/README.md
+++ b/README.md
@@ -10,3 +10,40 @@ To run the scraper, you can use the run script by typing `sh run_scraper.sh` int
 
 ## Running the API
 The best way to run the API right now is to run the command `FLASK_APP="app.py" FLASK_ENV=development flask run;`. Note that this is not the best way to run the scraper at this time.
+
+## Development
+
+We use CircleCI to lint the code and run tests in this repository, but you can (and should!) also run tests locally.
+
+The commands described below should all be run from within the virtual environment you’ve created for this project. If you used `install.sh` to get set up, you’ll need to activate your virtual environment before running them with the command:
+
+```sh
+$ source env/bin/activate
+```
+
+If you manage your environments differently (e.g. with Conda or Pyenv-Virtualenv), use whatever method you normally do to set up your environment.
+
+### Tests
+
+You can run tests using `pytest` like so:
+
+```sh
+# In the root directory of the project:
+$ python -m pytest -v .
+```
+
+### Linting and Code Conventions
+
+We use Pyflakes for linting. Many editors have support for running it while you type (either built-in or via a plugin), but you can also run it directly from the command line:
+
+```sh
+# In the root directory of the project:
+$ pyflakes .
+```
+
+We also use type annotations throughout the project. To check their validity with Mypy, run:
+
+```sh
+# In the root directory of the project:
+$ mypy .
+```

--- a/covid19_sfbayarea/news/feed.py
+++ b/covid19_sfbayarea/news/feed.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import locale
 from lxml.builder import E  # type: ignore
 import lxml.etree as ElementTree  # type: ignore
+from operator import attrgetter
 from typing import Dict, List, Optional, Any
 
 
@@ -91,7 +92,15 @@ class NewsFeed:
 
     def append(self, *items: NewsItem) -> None:
         self.items.extend(items)
-        self.items.sort(reverse=True, key=lambda item: item.date_published)
+        self.sort_items()
+
+    def sort_items(self) -> None:
+        # Sort primarily by date, then ID. Since date_published can be a
+        # date + time but, in practice, is often just a date, we frequently see
+        # items get shuffled between scraping runs because date_published is
+        # not very unique. Use the ID a [relatively] stable secondary criteria.
+        self.items.sort(reverse=True, key=attrgetter('id'))
+        self.items.sort(reverse=True, key=attrgetter('date_published'))
 
     def format_json_simple(self) -> Dict:
         """

--- a/covid19_sfbayarea/news/utils.py
+++ b/covid19_sfbayarea/news/utils.py
@@ -39,7 +39,7 @@ META_TAG_PATTERN = re.compile(
 # Matches an XML prolog that specifies character encoding:
 # <?xml version="1.0" encoding="ISO-8859-1"?>
 XML_PROLOG_PATTERN = re.compile(
-    b'<?xml\\s[^>]*encoding=[\'"]([^\'"]+)[\'"].*\?>',
+    b'<\\?xml\\s[^>]*encoding=[\'"]([^\'"]+)[\'"].*\\?>',
     re.IGNORECASE)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 mypy==0.770
 pyflakes==2.2.0
+pytest==5.4.3

--- a/tests/news/feed_test.py
+++ b/tests/news/feed_test.py
@@ -1,0 +1,33 @@
+from covid19_sfbayarea.news.feed import NewsFeed, NewsItem
+from datetime import datetime, timezone
+
+
+def test_feed_items_sort_latest_first() -> None:
+    feed = NewsFeed(title='Test Feed')
+    a = NewsItem(id='a', title='a', url='a',
+                 date_published=datetime(2020, 6, 2, tzinfo=timezone.utc))
+    b = NewsItem(id='b', title='b', url='b',
+                 date_published=datetime(2020, 6, 3, tzinfo=timezone.utc))
+    feed.append(a, b)
+
+    assert feed.items == [b, a]
+
+
+def test_feed_items_sort_stable() -> None:
+    '''
+    Unique feed items should always appear in the same order regardless of the
+    order in which they were added to the feed.
+    '''
+    a = NewsItem(id='a', title='a', url='a',
+                 date_published=datetime(2020, 6, 2, tzinfo=timezone.utc))
+    b = NewsItem(id='b', title='b', url='b',
+                 date_published=datetime(2020, 6, 2, tzinfo=timezone.utc))
+
+    feed = NewsFeed(title='Test Feed')
+    feed.append(a, b)
+    assert feed.items == [b, a]
+
+    # Make sure sorting is still stable even when added in the opposite order
+    feed2 = NewsFeed(title='Test Feed 2')
+    feed2.append(b, a)
+    assert feed.items == [b, a]


### PR DESCRIPTION
In situations where multiple feed items have the same publish time (usually because the county only specifies the date and not the time), we sometimes wind up with feed items getting a slightly different order between scraper runs. We now use the ID of the news items as an additional sort criteria to make sure they stay in the same order.

This change also adds some actual tests!

Fixes #88.