### PR TITLE
Add shebang line to executable bash scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 python3 -m venv env;
 source env/bin/activate;
 pip install -r requirements.txt;

--- a/run_scraper.sh
+++ b/run_scraper.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 source env/bin/activate;
 python3 scraper.py;

--- a/run_scraper_data.sh
+++ b/run_scraper_data.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 source env/bin/activate;
 python3 scraper_data.py $@;

--- a/run_scraper_news.sh
+++ b/run_scraper_news.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 source env/bin/activate;
 python3 scraper_news.py $@;


### PR DESCRIPTION
Back in #54, @rickpr made the `.sh` scripts and top-level `.py` scripts in this project executable. However, the bash scripts don't have a shebang line describing what interpreter should be used. Thankfully, most systems default to bash in this case, so everything usually works OK -- but that's no guarantee. This makes things a little safer by adding a shebang line specifying that bash should be used.

(Inspired by the small mess I ran into in #89.)