### PR TITLE
Limit news scrapers to a given timeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,113 @@ This project requires Python 3 to run. It was built specifically with version `3
 To install this project, you can simply run `./install.sh` in your terminal. This will set up the virtual environment and install all of the dependencies from `requirements.txt` and `requirements-dev.txt`. However, it will not keep the virtual environment running when the script ends. If you want to stay in the virtual environment, you will have to run `source env/bin/activate` separately from the install script.
 
 ## Running the scraper
-To run the scraper, you can use the run script by typing `sh run_scraper.sh` into your terminal. This will enable the virtual environment and run `scraper.py`. Once again, the virtual environment will not stay active after the script finishes running. If you want to run the scraper without the run script, enable the virtual environment, then run `python3 scraper.py`.
+
+This project includes three separate scraping tools for different purposes:
+
+- [Legacy CDS (Corona Data Scraper) Scraper](#legacy-scraper)
+- [County Website Scraper](#county-scraper)
+- [County News Scraper](#news-scraper)
+
+
+### <a id="legacy-scraper"></a> Legacy CDS Scraper
+
+The Legacy CDS Scraper loads Bay Area county data from the [Corona Data Scraper][CDS] project. Run it by typing into your terminal:
+
+```sh
+$ ./run_scraper.sh
+```
+
+This takes care of activating the virtual environment and running the actual Python scraping script. **If you are managing your virtual environments separately,** you can run the Python script directly with:
+
+```sh
+$ python3 scraper.py
+```
+
+
+### <a id="county-scraper"></a> County Website Scraper
+
+The newer county website scraper loads data directly from county data portals or by scraping counties’ public health websites. Running the shell script wrapper will take care of activating the virtual environment for you, or you can run the Python script directly:
+
+```sh
+# Run the wrapper:
+$ ./run_scraper_data.sh
+
+# Or run the script directly if you are managing virtual environments youself:
+$ python3 scraper_data.py
+```
+
+By default, it will output a JSON object with data for all currently supported counties. Use the `--help` option to see a information about additional arguments (the same options also work when running the Python script directly):
+
+```sh
+$ ./run_scraper_data.sh --help
+Usage: scraper_data.py [OPTIONS] [COUNTY]...
+
+  Create a .json with data for one or more counties. Supported counties:
+  alameda, san_francisco, solano.
+
+Options:
+  --output PATH  write output file to this directory
+  --help         Show this message and exit.
+```
+
+- To scrape a specific county or counties, list the counties you want. For example, to scraper only Alameda and Solano counties:
+
+    ```sh
+    $ ./run_scraper_data.sh alameda solano
+    ```
+
+- `--output` specifies a file to write to instead of your terminal’s STDOUT.
+
+
+### <a id="news-scraper"></a> County News Scraper
+
+The news scraper finds official county news, press releases, etc. relevant to COVID-19 and formats it as news feeds. Running the shell script wrapper will take care of activating the virtual environment for you, or you can run the Python script directly:
+
+```sh
+# Run the wrapper:
+$ ./run_scraper_news.sh
+
+# Or run the script directly if you are managing virtual environments youself:
+$ python3 scraper_news.py
+```
+
+By default, it will output a series of JSON Feed-formatted JSON objects — one for each county. Use the `--help` option to see a information about additional arguments (the same options also work when running the Python script directly):
+
+```sh
+$ ./run_scraper_news.sh --help
+Usage: scraper_news.py [OPTIONS] [COUNTY]...
+
+  Create a news feed for one or more counties. Supported counties: alameda,
+  contra_costa, marin, napa, san_francisco, san_mateo, santa_clara, solano,
+  sonoma.
+
+Options:
+  --from CLI_DATE                 Only include news items newer than this
+                                  date. Instead of a date, you can specify a
+                                  number of days ago, e.g. "14" for 2 weeks
+                                  ago.
+
+  --format [json_feed|json_simple|rss]
+  --output PATH                   write output file(s) to this directory
+  --help                          Show this message and exit.
+```
+
+- To scrape a specific county or counties, list the counties you want. For example, to scraper only Alameda and Solano counties:
+
+    ```sh
+    $ ./run_scraper_data.sh alameda solano
+    ```
+
+- `--from` sets the earliest date/time from which to include news items. It can be a date, like `2020-07-15`, a specific time, like `2020-07-15T10:00:00` for 10 am on July 15th, or a number of days before the current time, like `14` for the last 2 weeks.
+
+- `--format` sets the output format. Acceptable values are: `json_feed` (see the [JSON Feed spec][json_feed_spec]), `json_simple` (a simplified JSON format), or `rss` ([RSS v2][rss_spec]). Specify this option multiple times to output multiple formats, e.g:
+
+    ```sh
+    $ ./run_scraper_data.sh --format rss --format json_feed
+    ```
+
+- `--output` specifies a directory to write to instead of your terminal’s STDOUT. Each county and `--format` combination will create a separate file in the directory. If the directory does not exist, it will be created.
+
 
 ## Running the API
 The best way to run the API right now is to run the command `FLASK_APP="app.py" FLASK_ENV=development flask run;`. Note that this is not the best way to run the scraper at this time.
@@ -48,3 +154,8 @@ We also use type annotations throughout the project. To check their validity wit
 # In the root directory of the project:
 $ mypy .
 ```
+
+
+[CDS]: https://coronadatascraper.com/
+[json_feed_spec]: https://jsonfeed.org/
+[rss_spec]: https://www.rssboard.org/rss-specification

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ This project includes three separate scraping tools for different purposes:
 
 The Legacy CDS Scraper loads Bay Area county data from the [Corona Data Scraper][CDS] project. Run it by typing into your terminal:
 
-```sh
+```console
 $ ./run_scraper.sh
 ```
 
 This takes care of activating the virtual environment and running the actual Python scraping script. **If you are managing your virtual environments separately,** you can run the Python script directly with:
 
-```sh
+```console
 $ python3 scraper.py
 ```
 
@@ -34,7 +34,7 @@ $ python3 scraper.py
 
 The newer county website scraper loads data directly from county data portals or by scraping counties’ public health websites. Running the shell script wrapper will take care of activating the virtual environment for you, or you can run the Python script directly:
 
-```sh
+```console
 # Run the wrapper:
 $ ./run_scraper_data.sh
 
@@ -44,7 +44,7 @@ $ python3 scraper_data.py
 
 By default, it will output a JSON object with data for all currently supported counties. Use the `--help` option to see a information about additional arguments (the same options also work when running the Python script directly):
 
-```sh
+```console
 $ ./run_scraper_data.sh --help
 Usage: scraper_data.py [OPTIONS] [COUNTY]...
 
@@ -58,7 +58,7 @@ Options:
 
 - To scrape a specific county or counties, list the counties you want. For example, to scraper only Alameda and Solano counties:
 
-    ```sh
+    ```console
     $ ./run_scraper_data.sh alameda solano
     ```
 
@@ -69,7 +69,7 @@ Options:
 
 The news scraper finds official county news, press releases, etc. relevant to COVID-19 and formats it as news feeds. Running the shell script wrapper will take care of activating the virtual environment for you, or you can run the Python script directly:
 
-```sh
+```console
 # Run the wrapper:
 $ ./run_scraper_news.sh
 
@@ -79,7 +79,7 @@ $ python3 scraper_news.py
 
 By default, it will output a series of JSON Feed-formatted JSON objects — one for each county. Use the `--help` option to see a information about additional arguments (the same options also work when running the Python script directly):
 
-```sh
+```console
 $ ./run_scraper_news.sh --help
 Usage: scraper_news.py [OPTIONS] [COUNTY]...
 
@@ -100,7 +100,7 @@ Options:
 
 - To scrape a specific county or counties, list the counties you want. For example, to scraper only Alameda and Solano counties:
 
-    ```sh
+    ```console
     $ ./run_scraper_data.sh alameda solano
     ```
 
@@ -108,7 +108,7 @@ Options:
 
 - `--format` sets the output format. Acceptable values are: `json_feed` (see the [JSON Feed spec][json_feed_spec]), `json_simple` (a simplified JSON format), or `rss` ([RSS v2][rss_spec]). Specify this option multiple times to output multiple formats, e.g:
 
-    ```sh
+    ```console
     $ ./run_scraper_data.sh --format rss --format json_feed
     ```
 

--- a/covid19_sfbayarea/news/base.py
+++ b/covid19_sfbayarea/news/base.py
@@ -64,8 +64,8 @@ class NewsScraper:
 
     def _in_time_range(self, candidate: NewsItem) -> bool:
         time = candidate.date_published
-        return time < self.to_date and (not self.from_date or
-                                        time >= self.from_date)
+        return time <= self.to_date and (not self.from_date or
+                                         time >= self.from_date)
 
     @classmethod
     def get_news(cls, from_date: datetime = None, to_date: datetime = None) -> NewsFeed:

--- a/covid19_sfbayarea/news/san_mateo.py
+++ b/covid19_sfbayarea/news/san_mateo.py
@@ -67,7 +67,9 @@ class SanMateoNews(NewsScraper):
         feed = self.create_feed()
         xml = self.load_xml(self.URL)
         news = self.parse_feed(xml, self.URL)
-        feed.append(*news)
+        feed.append(*(item
+                      for item in news
+                      if self._in_time_range(item)))
         return feed
 
     def load_xml(self, url: str) -> bytes:

--- a/scraper_data.py
+++ b/scraper_data.py
@@ -13,8 +13,8 @@ COUNTY_NAMES : Tuple[str,...]= tuple(data_scrapers.scrapers.keys())
                     f'counties: {", ".join(COUNTY_NAMES)}.')
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
-@click.option('--output', help='write output file to this directory')
-
+@click.option('--output', metavar='PATH',
+              help='write output file to this directory')
 def main(counties: Tuple[str,...], output:str) -> None:
     out = dict()
     if len(counties) == 0:

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import click
+from datetime import datetime, timedelta
 from covid19_sfbayarea import news
+from covid19_sfbayarea.news.utils import parse_datetime
 from pathlib import Path
 from typing import cast, Tuple
 
@@ -8,21 +10,44 @@ from typing import cast, Tuple
 COUNTY_NAMES = cast(Tuple[str], tuple(news.scrapers.keys()))
 
 
+def cli_date(date_string: str) -> datetime:
+    '''Parse a CLI date or number of days into a TZ-aware datetime.'''
+    try:
+        days = float(date_string)
+        if days <= 0:
+            raise click.BadParameter('must be a positive number or date')
+        return datetime.now().astimezone() - timedelta(days=days)
+    except ValueError:
+        pass
+
+    try:
+        value = parse_datetime(date_string)
+    except Exception:
+        raise click.BadParameter(f'"{date_string}" is not a date')
+    if value >= datetime.now().astimezone():
+        raise click.BadParameter(f'must be a date in the past.')
+
+    return value
+
+
 @click.command(help='Create a news feed for one or more counties. Supported '
                     f'counties: {", ".join(COUNTY_NAMES)}.')
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
+@click.option('--from', 'from_', type=cli_date, default='31',
+              help='Only include news items newer than this date. You can '
+                   'specify a number of days ago, e.g. "14" for 2 weeks ago.')
 @click.option('--format', default=('json_feed',),
               type=click.Choice(('json_feed', 'json_simple', 'rss')),
               multiple=True)
 @click.option('--output', help='write output file(s) to this directory')
-def main(counties: Tuple[str], format: str, output: str) -> None:
+def main(counties: Tuple[str], from_: datetime, format: str, output: str) -> None:
     if len(counties) == 0:
         counties = COUNTY_NAMES
 
     # Do the work!
     for county in counties:
-        feed = news.scrapers[county].get_news()
+        feed = news.scrapers[county].get_news(from_date=from_)
 
         for format_name in format:
             if format_name == 'json_simple':

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -35,12 +35,14 @@ def cli_date(date_string: str) -> datetime:
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
 @click.option('--from', 'from_', type=cli_date, default='31',
-              help='Only include news items newer than this date. You can '
-                   'specify a number of days ago, e.g. "14" for 2 weeks ago.')
+              help='Only include news items newer than this date. Instead of '
+                   'a date, you can specify a number of days ago, e.g. "14" '
+                   'for 2 weeks ago.')
 @click.option('--format', default=('json_feed',),
               type=click.Choice(('json_feed', 'json_simple', 'rss')),
               multiple=True)
-@click.option('--output', help='write output file(s) to this directory')
+@click.option('--output', metavar='PATH',
+              help='write output file(s) to this directory')
 def main(counties: Tuple[str], from_: datetime, format: str, output: str) -> None:
     if len(counties) == 0:
         counties = COUNTY_NAMES

--- a/scraper_news.py
+++ b/scraper_news.py
@@ -25,7 +25,7 @@ def cli_date(date_string: str) -> datetime:
     except Exception:
         raise click.BadParameter(f'"{date_string}" is not a date')
     if value >= datetime.now().astimezone():
-        raise click.BadParameter(f'must be a date in the past.')
+        raise click.BadParameter('must be a date in the past.')
 
     return value
 


### PR DESCRIPTION
Use the new `--from` CLI argument to set a timeframe for news. It can be a date after which news items should be included OR a number of days before the current time:

```sh
# Scrape all news after June 5, 2020
$ python scraper_news.py --from 2020-06-05

# Scrape all news after one week ago
$ python scraper_news.py --from 7
```

The default is "31" -- i.e. the past month.

Fixes #43.