### PR TITLE
Default to *all* counties for news scraper CLI

### DIFF
--- a/scraper_news.py
+++ b/scraper_news.py
@@ -3,25 +3,23 @@ import click
 import json
 from covid19_sfbayarea import news
 from pathlib import Path
-from typing import Tuple
+from typing import cast, Tuple
 
 
-COUNTY_NAMES = tuple(news.scrapers.keys())
+COUNTY_NAMES = cast(Tuple[str], tuple(news.scrapers.keys()))
 
 
 @click.command(help='Create a news feed for one or more counties. Supported '
                     f'counties: {", ".join(COUNTY_NAMES)}.')
 @click.argument('counties', metavar='[COUNTY]...', nargs=-1,
                 type=click.Choice(COUNTY_NAMES, case_sensitive=False))
-@click.option('--format', default=('json_simple',),
+@click.option('--format', default=('json_feed',),
               type=click.Choice(('json_feed', 'json_simple', 'rss')),
               multiple=True)
 @click.option('--output', help='write output file(s) to this directory')
 def main(counties: Tuple[str], format: str, output: str) -> None:
     if len(counties) == 0:
-        # FIXME: this should be COUNTY_NAMES, but we need to fix how the
-        # stop-covid19-sfbayarea project uses this first.
-        counties = ('san_francisco',)
+        counties = COUNTY_NAMES
 
     # Do the work!
     for county in counties:


### PR DESCRIPTION
If you didn't specify any county names to scrape, the news scraper used to only output news for San Francisco. It now outputs news for all counties instead, which is a more sensible default and matches up with the data side. (Code that depended on the old default has now all been fixed, so this change is finally safe.)

While we’re at it, this also updates the default format from simple JSON to JSON feed.

Fixes #92.