### PR TITLE
Issue #29: Get CA COVID-19 Hospital Data

### DIFF
--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -24,7 +24,9 @@ logging.basicConfig(level=logging.INFO)
 
 
 def get_county(county: str) -> Dict:
-    """Return data just for the selected county. Include field notes."""
+    """Return data just for the selected county. Include field notes.
+    This is basically an alias for `get_timeseries()` provided for consistency.
+    """
     data = get_timeseries(county)
 
     return data

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -120,6 +120,19 @@ def truncate_ts(ts: str) -> str:
     return trunc_ts
 
 
+def convert_null(record: Dict) -> Dict:
+    """Convert any null values to -1"""
+    for k, v in record.items():
+
+        if v is None:
+            record[k] = -1
+
+        else:
+            continue
+
+    return record
+
+
 if __name__ == "__main__":
     """When run as a script, prints all data to stdout"""
     print(json.dumps(get_timeseries(), indent=4))

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -90,5 +90,5 @@ def get_timeseries(county: str = "all") -> Dict:
 
 
 if __name__ == "__main__":
-    """ When run as a script, prints the data to stdout"""
-    print(json.dumps(get_timeseries("San Francisco"), indent=4))
+    """When run as a script, prints all data to stdout"""
+    print(json.dumps(get_timeseries(), indent=4))

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -133,6 +133,30 @@ def convert_null(record: Dict) -> Dict:
     return record
 
 
+def floats_to_ints(record: Dict) -> Dict:
+    """Convert zero-point floats for numeric fields to ints"""
+    fields: List = [
+        "all_hospital_beds",
+        "hospitalized_covid_confirmed_patients",
+        "hospitalized_covid_patients",
+        "hospitalized_suspected_covid_patients",
+        "icu_available_beds",
+        "icu_covid_confirmed_patients",
+        "icu_suspected_covid_patients",
+    ]
+
+    for field in fields:
+        val = record.get(field)
+
+        if val is None:
+            continue
+
+        else:
+            record[field] = int(val)
+
+    return record
+
+
 if __name__ == "__main__":
     """When run as a script, prints all data to stdout"""
     print(json.dumps(get_timeseries(), indent=4))

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import requests
+from datetime import datetime
+from dateutil import tz
 from typing import Dict
 
 # This module fetches COVID-19 hospital data from the CA.gov open data portal.
@@ -19,6 +21,9 @@ CAGOV_BASEURL = "https://data.ca.gov"
 CAGOV_API = "/api/3/action/datastore_search"
 HOSPITALS_RESOURCE_ID = "42d33765-20fd-44b8-a978-b083b7542225"
 RESULTS_LIMIT = 50
+
+# For the output data
+SERIES_NAME = "CA Hospitals"
 
 logging.basicConfig(level=logging.INFO)
 
@@ -79,6 +84,10 @@ def get_timeseries(county: str = "all") -> Dict:
             else:
                 break
 
+        # Package up the data
+        now = datetime.now(tz.tzutc()).isoformat()
+        ts_data["name"] = SERIES_NAME + " " + county
+        ts_data["update_time"] = now
         ts_data["series"] = timeseries
         logging.info("Collected all pages")
 

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import requests
-from typing import Dict, List
+from typing import Dict
 
 # This module fetches COVID-19 hospital data from the CA.gov open data portal.
 # The input data is fetched from an API endpoint, and appears to be updated at

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import requests
+
+# This module fetches COVID-19 hospital data from the CA.gov open data portal.
+# The input data is fetched from an API endpoint, and appears to be updated at
+# least daily.  Hospital stats, such as number of available ICU beds, are
+# provided at the county level. This module's top-level function takes a county
+# as an arg and returns the data for that county as JSON.
+
+# TODO Document data model
+
+# URLs and APIs
+HOSPITALS_LANDING_PAGE = "https://data.ca.gov/dataset/covid-19-hospital-data#"
+CAGOV_API_BASEURL = "https://data.ca.gov/api/3/action/datastore_search"
+HOSPITALS_RESOURCE_ID = "42d33765-20fd-44b8-a978-b083b7542225"
+RESULTS_LIMIT = 50
+
+
+params = {"resource_id": HOSPITALS_RESOURCE_ID, "limit": RESULTS_LIMIT}
+r = requests.get(CAGOV_API_BASEURL, params=params)
+print(r.text)

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -23,7 +23,8 @@ HOSPITALS_RESOURCE_ID = "42d33765-20fd-44b8-a978-b083b7542225"
 RESULTS_LIMIT = 50
 
 # For the output data
-SERIES_NAME = "CA Hospitals"
+SERIES_NAME = "Hospitalization"
+BAYPD_META = "This data was pulled from the data.ca.gov CKAN Data API"
 
 logging.basicConfig(level=logging.INFO)
 
@@ -85,9 +86,15 @@ def get_timeseries(county: str = "all") -> Dict:
                 break
 
         # Package up the data
+        if county == "all":
+            ts_data["name"] = f"{SERIES_NAME} - All CA Counties"
+        else:
+            ts_data["name"] = f"{SERIES_NAME} - {county} County"
+
         now = datetime.now(tz.tzutc()).isoformat()
-        ts_data["name"] = SERIES_NAME + " " + county
         ts_data["update_time"] = now
+        ts_data["source_url"] = HOSPITALS_LANDING_PAGE
+        ts_data["meta_from_baypd"] = BAYPD_META
         ts_data["series"] = timeseries
         logging.info("Collected all pages")
 

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -114,6 +114,23 @@ def get_timeseries(county: str = "all") -> Dict:
         return ts_data
 
 
+def standardize_data(record: Dict) -> Dict:
+    """Transform certain data fields to make them conform to BAPD style
+
+    Specifically:
+    - truncate timestamps to ISO 8601-formatted dates
+    - convert all 'null' values to -1
+    - cast zero-point floats as int
+
+    Also, the key 'todays_date' is converted to 'report_date' for clarity.
+    """
+    record["report_date"] = truncate_ts(record.pop("todays_date"))
+    record = convert_null(record)
+    record = floats_to_ints(record)
+
+    return record
+
+
 def truncate_ts(ts: str) -> str:
     """Truncate a timestampe to an ISO 8601-formatted date"""
     trunc_ts = parse(ts).date().isoformat()

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -46,7 +46,7 @@ def get_timeseries(county: str = "all") -> Dict:
     if county == "all":
         ts_data["name"] = f"{SERIES_NAME} - All CA Counties"
     else:
-        ts_data["name"] = f"{SERIES_NAME} - {county} County"
+        ts_data["name"] = f"{SERIES_NAME} - {county.title()} County"
 
     now = datetime.now(tz.tzutc()).isoformat()
     ts_data["update_time"] = now
@@ -60,7 +60,7 @@ def get_timeseries(county: str = "all") -> Dict:
     }
 
     if county != "all":
-        params["q"] = county
+        params["q"] = county.title()
 
     url = CAGOV_BASEURL + CAGOV_API
 

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -50,7 +50,7 @@ def get_timeseries(county: str = "all") -> Dict:
     else:
         ts_data["name"] = f"{SERIES_NAME} - {county.title()} County"
 
-    now = datetime.now(tz.tzutc()).isoformat()
+    now = datetime.now(tz.tzutc()).isoformat(timespec="minutes")
     ts_data["update_time"] = now
     ts_data["source_url"] = HOSPITALS_LANDING_PAGE
     ts_data["meta_from_baypd"] = BAYPD_META

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -124,12 +124,14 @@ def standardize_data(record: Dict) -> Dict:
 
     Specifically:
     - truncate timestamps to ISO 8601-formatted dates
+    - remove "rank" field, if it exists
     - convert all 'null' values to -1
     - cast zero-point floats as int
 
     Also, the key 'todays_date' is converted to 'report_date' for clarity.
     """
     record["report_date"] = truncate_ts(record.pop("todays_date"))
+    record.pop("rank", None)
     record = convert_null(record)
     record = floats_to_ints(record)
 

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -57,9 +57,9 @@ def get_timeseries(county: str = "all") -> Dict:
             total = int(results.get("total"))
 
             # Get notes only on the first pull
-            if not ts_data.get("field_notes"):
+            if not ts_data.get("meta_from_source"):
                 notes = results.get("fields")
-                ts_data["field_notes"] = notes
+                ts_data["meta_from_source"] = notes
 
             else:
                 pass

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -5,6 +5,7 @@ import logging
 import requests
 from datetime import datetime
 from dateutil import tz
+from dateutil.parser import parse
 from typing import Any, Dict, List, Union
 
 # This module fetches COVID-19 hospital data from the CA.gov open data portal.
@@ -111,6 +112,12 @@ def get_timeseries(county: str = "all") -> Dict:
 
     finally:
         return ts_data
+
+
+def truncate_ts(ts: str) -> str:
+    """Truncate a timestampe to an ISO 8601-formatted date"""
+    trunc_ts = parse(ts).date().isoformat()
+    return trunc_ts
 
 
 if __name__ == "__main__":

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -87,7 +87,7 @@ def get_timeseries(county: str = "all") -> Dict:
     except AttributeError:
         logging.exception("Error parsing response")
 
-    except requests.Exceptions.RequestExceptions:
+    except requests.exceptions.RequestException:
         logging.exception("Error fetching from API")
 
 

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -48,7 +48,7 @@ def get_timeseries() -> List:
         logging.info(f"Got {results_counter} results out of {total} ...")
         more = results.get("_links").get("next")
 
-        # Don't ask for more pages than are ther
+        # Don't ask for more pages than there are
         if more and results_counter <= total:
             url = CAGOV_BASEURL + more
             params = None

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+import logging
 import requests
 from typing import Dict, List
 
@@ -14,22 +15,48 @@ from typing import Dict, List
 
 # URLs and APIs
 HOSPITALS_LANDING_PAGE = "https://data.ca.gov/dataset/covid-19-hospital-data#"
-CAGOV_API_BASEURL = "https://data.ca.gov/api/3/action/datastore_search"
+CAGOV_BASEURL = "https://data.ca.gov"
+CAGOV_API = "/api/3/action/datastore_search"
 HOSPITALS_RESOURCE_ID = "42d33765-20fd-44b8-a978-b083b7542225"
 RESULTS_LIMIT = 50
+
+logging.basicConfig(level=logging.INFO)
 
 
 def get_timeseries() -> List:
     """Fetch all pages of timeseries data from API endpoint"""
     timeseries = []
+    results_counter = 0
 
     params = {"resource_id": HOSPITALS_RESOURCE_ID, "limit": RESULTS_LIMIT}
-    r = requests.get(CAGOV_API_BASEURL, params=params).json()
+    url = CAGOV_BASEURL + CAGOV_API
 
-    # TODO get notes for each field
+    # Handle the pagination
+    while True:
+        if params:
+            r = requests.get(url, params=params).json()
+        else:
+            r = requests.get(url).json()
 
-    records = r["result"].get("records")
-    timeseries.extend(records)
+        # TODO get notes for each field
+        results = r.get("result")
+        total = int(results.get("total"))
+        records = results.get("records")
+        timeseries.extend(records)
+
+        results_counter = len(timeseries)
+        logging.info(f"Got {results_counter} results out of {total} ...")
+        more = results.get("_links").get("next")
+
+        # Don't ask for more pages than are ther
+        if more and results_counter <= total:
+            url = CAGOV_BASEURL + more
+            params = None
+
+        else:
+            break
+
+    logging.info("Collected all pages")
 
     return timeseries
 

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import json
 import requests
+from typing import Dict, List
 
 # This module fetches COVID-19 hospital data from the CA.gov open data portal.
 # The input data is fetched from an API endpoint, and appears to be updated at
@@ -17,6 +19,21 @@ HOSPITALS_RESOURCE_ID = "42d33765-20fd-44b8-a978-b083b7542225"
 RESULTS_LIMIT = 50
 
 
-params = {"resource_id": HOSPITALS_RESOURCE_ID, "limit": RESULTS_LIMIT}
-r = requests.get(CAGOV_API_BASEURL, params=params)
-print(r.text)
+def get_timeseries() -> List:
+    """Fetch all pages of timeseries data from API endpoint"""
+    timeseries = []
+
+    params = {"resource_id": HOSPITALS_RESOURCE_ID, "limit": RESULTS_LIMIT}
+    r = requests.get(CAGOV_API_BASEURL, params=params).json()
+
+    # TODO get notes for each field
+
+    records = r["result"].get("records")
+    timeseries.extend(records)
+
+    return timeseries
+
+
+if __name__ == "__main__":
+    """ When run as a script, prints the data to stdout"""
+    print(json.dumps(get_timeseries(), indent=4))

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -42,6 +42,7 @@ def get_timeseries(county: str = "all") -> Dict:
     """Fetch all pages of timeseries data from API endpoint"""
     ts_data: Dict[str, Union[str, List]] = {}
     timeseries: List[Dict[str, Any]] = []
+    series_standardized: List[Dict[str, Any]] = []
 
     # Add header data
     if county == "all":
@@ -101,7 +102,11 @@ def get_timeseries(county: str = "all") -> Dict:
             else:
                 break
 
-        ts_data["series"] = timeseries
+        # standardize the format of the data in a new list
+        for record in timeseries:
+            series_standardized.append(standardize_data(record))
+
+        ts_data["series"] = series_standardized
         logging.info("Collected all pages")
 
     except AttributeError:

--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -79,7 +79,7 @@ def get_timeseries(county: str = "all") -> Dict:
             else:
                 break
 
-        ts_data["timeseries"] = timeseries
+        ts_data["series"] = timeseries
         logging.info("Collected all pages")
 
         return ts_data

--- a/data_models/README.md
+++ b/data_models/README.md
@@ -136,8 +136,12 @@ The fields will be used for normalizing the county case and death tabulations, a
         }
     }
 ```
+
 5. __Hospitalization Data__
-California COVID-19 hospitalization data is retrieved separately from the the [California Health and Human Services Open Data Portal (CHHS)](https://data.ca.gov/dataset/covid-19-hospital-data#). The keys for the top-level data points `name`, `update_time`, `source_url`, `meta_from_source`, and `meta_from_baypd` are the same as the model described above. However, the structure of the data for `meta_from_source` and `series` differs.
+
+California COVID-19 hospitalization data is retrieved separately from the the
+[California Health and Human Services Open Data Portal
+(CHHS)](https://data.ca.gov/dataset/covid-19-hospital-data#). The keys for the  top-level data points `name`, `update_time`, `source_url`, `meta_from_source`, and `meta_from_baypd` are the same as the model described above. However, the structure of the data for `meta_from_source` and `series` differs. The model for the hospitalization data is in [hospitals_data_model.json](./hospitals_data_model.json).
 
 `meta_from_source` holds a list of dicts describing each field in the data, provided directly from CHHS. Each dict, except for the first describing the `_id` field, has the keys `info`, `type`, and `id`. Here is an example:
 
@@ -160,20 +164,22 @@ California COVID-19 hospitalization data is retrieved separately from the the [C
         -- snip --
 ```
 
-Each entry in `series` is a flat record with each of the fields described in `meta_from_source`, one for each day on which an observation was made:
+Each entry in `series` is a flat record with each of the fields described in
+`meta_from_source`, one for each day on which an observation was made. As
+described above, null or default values are represented as `-1`.
 
 ```
         {
-            "icu_covid_confirmed_patients": 0.0,
-            "icu_suspected_covid_patients": 0.0,
-            "hospitalized_covid_patients": null,
-            "hospitalized_suspected_covid_patients": 10.0,
-            "icu_available_beds": 18.0,
-            "county": "Humboldt",
-            "hospitalized_covid_confirmed_patients": 1.0,
-            "_id": 1,
-            "all_hospital_beds": null,
-            "todays_date": "2020-03-29T00:00:00"
+            "icu_covid_confirmed_patients": -1,
+            "icu_suspected_covid_patients": -1,
+            "hospitalized_covid_patients": -1,
+            "hospitalized_suspected_covid_patients": -1,
+            "icu_available_beds": -1,
+            "county": "Name1 Name2",
+            "hospitalized_covid_confirmed_patients": -1,
+            "_id": -1,
+            "all_hospital_beds": -1,
+            "report_date": "yyyy-mm-dd"
         }
 ```
 

--- a/data_models/README.md
+++ b/data_models/README.md
@@ -136,8 +136,48 @@ The fields will be used for normalizing the county case and death tabulations, a
         }
     }
 ```
-5. __Hospitalization Data__  
-We plan to retrieve hospitalization data by county from a common source, the [California Health and Human Services Open Data Portal (CHHS)](https://data.chhs.ca.gov/dataset/california-covid-19-hospital-data-and-case-statistics/resource/6cd8d424-dfaa-4bdd-9410-a3d656e1176e?inner_span=True.). These datapoints are not currently reflected in the data model.
+5. __Hospitalization Data__
+California COVID-19 hospitalization data is retrieved separately from the the [California Health and Human Services Open Data Portal (CHHS)](https://data.ca.gov/dataset/covid-19-hospital-data#). The keys for the top-level data points `name`, `update_time`, `source_url`, `meta_from_source`, and `meta_from_baypd` are the same as the model described above. However, the structure of the data for `meta_from_source` and `series` differs.
+
+`meta_from_source` holds a list of dicts describing each field in the data, provided directly from CHHS. Each dict, except for the first describing the `_id` field, has the keys `info`, `type`, and `id`. Here is an example:
+
+```
+    "meta_from_source": [
+        {
+            "type": "int",
+            "id": "_id"
+        },
+        {
+            "info": {
+                "notes": "The County where the hospital is located. None of the consolidated reporters had hospitals in different counties.",
+                "type_override": "",
+                "label": "County"
+            },
+            "type": "text",
+            "id": "county"
+        }
+
+        -- snip --
+```
+
+Each entry in `series` is a flat record with each of the fields described in `meta_from_source`, one for each day on which an observation was made:
+
+```
+        {
+            "icu_covid_confirmed_patients": 0.0,
+            "icu_suspected_covid_patients": 0.0,
+            "hospitalized_covid_patients": null,
+            "hospitalized_suspected_covid_patients": 10.0,
+            "icu_available_beds": 18.0,
+            "county": "Humboldt",
+            "hospitalized_covid_confirmed_patients": 1.0,
+            "_id": 1,
+            "all_hospital_beds": null,
+            "todays_date": "2020-03-29T00:00:00"
+        }
+```
+
+The `name` value starts with "Hospitalization - " and then the full name of the county (e.g. "Hospitalization - Alameda County"). If the argument `"all"` is passed to `get_county()` (the default in the `get_timeseries()` function), then data for all counties will be fetched, and the name value will be "Hospitalization - All CA Counties"
 
 # Notes and resources 
 Please contribute!

--- a/data_models/hospitals_data_model.json
+++ b/data_models/hospitals_data_model.json
@@ -1,0 +1,31 @@
+{
+    "name": "Hospitalization - Name1 Name2 County | All CA Counties",
+    "update_time": "yyyy-mm-ddThh:mmz",
+    "source_url": "POINT TO LANDING PAGES, IN CASE ENDPOINTS CHANGE",
+    "meta_from_baypd": "STORE IMPORTANT NOTES ABOUT OUR METHODS HERE",
+    "meta_from_source": [
+        {
+            "info": {
+                "notes": "NOTES ABOUT THE FIELD, IF ANY",
+                "type_override": "FIELD DATA TYPE - GENERALLY SAME AS 'TYPE' BELOW",
+                "label": "HUMAN-FRIENDLY FIELD LABEL"
+            },
+            "type": "FIELD DATA TYPE - SQL-LIKE (E.G. 'int', 'numeric', 'text')",
+            "id": "FIELD ID IN SERIES DATA"
+        }
+    ],
+    "series": [
+        {
+            "icu_covid_confirmed_patients": -1,
+            "icu_suspected_covid_patients": -1,
+            "hospitalized_covid_patients": -1,
+            "hospitalized_suspected_covid_patients": -1,
+            "icu_available_beds": -1,
+            "county": "Name1 Name2",
+            "hospitalized_covid_confirmed_patients": -1,
+            "_id": -1,
+            "all_hospital_beds": -1,
+            "report_date": "yyyy-mm-dd"
+        }
+    ]
+}

--- a/tests/data/test_hospitals.py
+++ b/tests/data/test_hospitals.py
@@ -7,28 +7,36 @@ Tests for functions in hospitals.py
 from covid19_sfbayarea.data import hospitals
 
 
+SAMPLE_RECORD = {
+    'icu_covid_confirmed_patients': 4.0,
+    'icu_suspected_covid_patients': 2.0,
+    'hospitalized_covid_patients': None,
+    'hospitalized_suspected_covid_patients': 9.0,
+    'icu_available_beds': 16.0,
+    'rank': 0.0573088,
+    'county': 'Marin',
+    'hospitalized_covid_confirmed_patients': 10.0,
+    '_id': 103,
+    'all_hospital_beds': None,
+    'todays_date': '2020-03-30T00:00:00'
+}
+
+
 def test_truncate_ts():
-    ts = "2020-03-29T00:00:00"
+    ts = SAMPLE_RECORD.get("todays_date")
     trunc_ts = hospitals.truncate_ts(ts)
-    assert trunc_ts == "2020-03-29"
+    assert trunc_ts == "2020-03-30"
 
 
 def test_convert_null():
-    record = {
-        'icu_covid_confirmed_patients': 4.0,
-        'icu_suspected_covid_patients': 2.0,
-        'hospitalized_covid_patients': None,
-        'hospi talized_suspected_covid_patients': 9.0,
-        'icu_available_beds': 16.0,
-        'rank': 0.0573088,
-        'county': 'Marin',
-        'hospitalized_covid_confirmed_patients': 10.0,
-        '_id': 103,
-        'all_hospital_beds': None,
-        'report_date': '2020-03-30'
-    }
-
-    converted = hospitals.convert_null(record)
+    converted = hospitals.convert_null(SAMPLE_RECORD)
     assert converted.get("hospitalized_covid_patients") == -1
     assert converted.get("all_hospital_beds") == -1
     assert converted.get("icu_available_beds") == 16.0
+
+
+def test_floats_to_ints():
+    converted = hospitals.floats_to_ints(SAMPLE_RECORD)
+    assert type(converted.get("icu_covid_confirmed_patients")) is int
+    assert converted.get("icu_covid_confirmed_patients") == int(4)
+    assert converted.get("icu_available_beds") == int(16)

--- a/tests/data/test_hospitals.py
+++ b/tests/data/test_hospitals.py
@@ -27,7 +27,6 @@ SAMPLE_OUTPUT = {
     'hospitalized_covid_patients': -1,
     'hospitalized_suspected_covid_patients': 9,
     'icu_available_beds': 16,
-    'rank': 0.0573088,
     'county': 'Marin',
     'hospitalized_covid_confirmed_patients': 10,
     '_id': 103,

--- a/tests/data/test_hospitals.py
+++ b/tests/data/test_hospitals.py
@@ -21,6 +21,20 @@ SAMPLE_RECORD = {
     'todays_date': '2020-03-30T00:00:00'
 }
 
+SAMPLE_OUTPUT = {
+    'icu_covid_confirmed_patients': 4,
+    'icu_suspected_covid_patients': 2,
+    'hospitalized_covid_patients': -1,
+    'hospitalized_suspected_covid_patients': 9,
+    'icu_available_beds': 16,
+    'rank': 0.0573088,
+    'county': 'Marin',
+    'hospitalized_covid_confirmed_patients': 10,
+    '_id': 103,
+    'all_hospital_beds': -1,
+    'report_date': '2020-03-30'
+}
+
 
 def test_truncate_ts():
     ts = SAMPLE_RECORD.get("todays_date")
@@ -40,3 +54,8 @@ def test_floats_to_ints():
     assert type(converted.get("icu_covid_confirmed_patients")) is int
     assert converted.get("icu_covid_confirmed_patients") == int(4)
     assert converted.get("icu_available_beds") == int(16)
+
+
+def test_standardize_data():
+    standardized = hospitals.standardize_data(SAMPLE_RECORD)
+    assert standardized == SAMPLE_OUTPUT

--- a/tests/data/test_hospitals.py
+++ b/tests/data/test_hospitals.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+"""
+Tests for functions in hospitals.py
+"""
+
+from covid19_sfbayarea.data import hospitals
+
+
+def test_truncate_ts():
+    ts = "2020-03-29T00:00:00"
+    trunc_ts = hospitals.truncate_ts(ts)
+    assert trunc_ts == "2020-03-29"
+
+
+def test_convert_null():
+    record = {
+        'icu_covid_confirmed_patients': 4.0,
+        'icu_suspected_covid_patients': 2.0,
+        'hospitalized_covid_patients': None,
+        'hospi talized_suspected_covid_patients': 9.0,
+        'icu_available_beds': 16.0,
+        'rank': 0.0573088,
+        'county': 'Marin',
+        'hospitalized_covid_confirmed_patients': 10.0,
+        '_id': 103,
+        'all_hospital_beds': None,
+        'report_date': '2020-03-30'
+    }
+
+    converted = hospitals.convert_null(record)
+    assert converted.get("hospitalized_covid_patients") == -1
+    assert converted.get("all_hospital_beds") == -1
+    assert converted.get("icu_available_beds") == 16.0


### PR DESCRIPTION
This is a PR to add a script to fetch hospitalization data from the data.ca.gov API, raised in issue # 29. I've tried to keep the output model as consistent as possible with the existing model, although there are necessarily some differences. I've also added some documentation of the output model in the README. I included logging for easier debugging/transparency, but that can be removed for consistency. Let me know if you spot bugs or other issues.