### PR TITLE
Add Dockerfile that works for development use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# This Docker image setup is designed primarily for development use. You *can*
+# use it to run the scraper tools in a "production" capacity, but it's a lot
+# heavier weight, with extra tools & dependencies, than you'll need.
+FROM python:3.8-slim-buster
+
+# Debian does not support a stable package for Firefox. Instead, it has
+# "Firefox-ESR (Extended Support Release)", which is not very up-to-date, and
+# does not seem to work too well with geckodriver. (It might be possible, but
+# certainly needs some massaging I haven't figured out.)
+# 
+# Instead, use Debian's "unstable" source to get an up-to-date Firefox.
+# We can also install Firefox by downloading the binary from Mozilla, but using
+# APT helps make sure we have all the necessary dependencies.
+# 
+# More about Firefox on Debian: https://wiki.debian.org/Firefox
+RUN sh -c 'echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list'
+RUN sh -c 'echo "APT::Default-Release "stable";" >> /etc/apt/apt.conf' 
+RUN apt-get update && apt-get install -y -t unstable firefox
+# Install other binary dependencies needed for our Python app. This is mainly
+# about libxml2 & libxslt, which are required for Python lxml.
+# NOTE: we have to install the unstable versions of these packages because
+# Firefox *also* uses some of them, and it requires newer versions than are
+# supported by Debian's stable source.
+RUN apt-get update && apt-get install -y -t unstable \
+    gcc g++ pkg-config libxml2-dev libxslt-dev
+
+# Install Geckodriver manually because the webdrivermanager package we normally
+# use to install it currently has issues on Linux.
+RUN apt-get update && apt-get install -y curl
+RUN mkdir /temp-install && \
+    cd /temp-install && \
+    curl --location 'https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz' > geckodriver.tar.gz && \
+    tar -xzf geckodriver.tar.gz && \
+    mv geckodriver /usr/local/bin/ && \
+    cd .. && \
+    rm -rf temp-install
+
+# The app source will be installed in /app, so make that the working directory.
+WORKDIR /app
+
+# Copy our dependency files and install from them separate from the rest of the
+# app source so the can be cached more aggressively than the rest of the code.
+ADD requirements.txt /app
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
+ADD requirements-dev.txt /app
+RUN pip install --trusted-host pypi.python.org -r requirements-dev.txt
+
+# Copy the rest of the source.
+ADD . /app
+
+# Since this is designed for development, launch with bash by default.
+# NOTE: You can always launch the container directly into the scraper instead:
+#     docker run python3 scraper_data.py
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # data-covid19-sfbayarea
+
 Processes for sourcing data for the Stop COVID-19 SF Bay Area dashboard, which you can find [here](https://stop-covid19-sfbayarea.netlify.com/), or [on GitHub](https://github.com/sfbrigade/stop-covid19-sfbayarea).  
 **We are looking for feedback**! Did you come here looking for a data API? Do you have questions, comments, or concerns? Don't leave yet - let us know how you are using this project and what you'd like to see implemented. Please leave us your two cents over in Issues under [#101 Feedback Mega Thread](https://github.com/sfbrigade/data-covid19-sfbayarea/issues/101).
 
+
 ## Installation
+
 This project requires Python 3 to run. It was built specifically with version `3.7.4`, but it may run with other versions. However, it does take advantage of insertion-ordered dictionaries which are only reliable in `3.7+`.
 To install this project, you can simply run `./install.sh` in your terminal. This will set up the virtual environment and install all of the dependencies from `requirements.txt` and `requirements-dev.txt`. However, it will not keep the virtual environment running when the script ends. If you want to stay in the virtual environment, you will have to run `source env/bin/activate` separately from the install script.
+
 
 ## Running the scraper
 
@@ -13,6 +17,8 @@ This project includes three separate scraping tools for different purposes:
 - [Legacy CDS (Corona Data Scraper) Scraper](#legacy-scraper)
 - [County Website Scraper](#county-scraper)
 - [County News Scraper](#news-scraper)
+
+**You can also run each of these tools in Docker.** See the [“using Docker”](#using-docker) section below.
 
 
 ### <a id="legacy-scraper"></a> Legacy CDS Scraper
@@ -113,6 +119,34 @@ Options:
     ```
 
 - `--output` specifies a directory to write to instead of your terminal’s STDOUT. Each county and `--format` combination will create a separate file in the directory. If the directory does not exist, it will be created.
+
+
+## Using Docker
+
+As an alternative to installing and running the tools normally, you can use [Docker](https://www.docker.com/) to install and run them. This is especially helpful on Windows, where setting up Selenium and other Linux tools the scraper can be complicated.
+
+1. Download and install Docker from https://www.docker.com/ (You’ll probably need to create a Docker account as well if you don’t already have one.)
+
+2. Now run [any of the tools](#running-the-scraper) by adding their command after `./run_docker.sh`. For example, to run the news scraper:
+
+    ```sh
+    $ ./run_docker.sh python scraper_data.py
+    ```
+
+    Under the hood, this builds the Docker container and then runs the specified command in it.
+
+    Docker acts kind of like a virtual machine, and you can also simply get yourself a command prompt inside the docker container by running `./run_docker.sh` with no arguments:
+
+    ```sh
+    $ ./run_docker.sh
+    # This will output information about the build, and then give you a
+    # command prompt:
+    root@ca87fa64d822:/app#
+
+    # You can now run commands like the data scraper as normal from the prompt:
+    root@ca87fa64d822:/app# python scraper_data.py
+    root@ca87fa64d822:/app# python scraper_news.py
+    ```
 
 
 ## Data Models

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker build -t data-covid19-sfbayarea .
+docker run -it data-covid19-sfbayarea $@


### PR DESCRIPTION
Since it can be tough to get all the pieces installed and working right when using WSL on Windows, this dockerfile provides a way to develop and run the app in a container with all the necessary dependencies. You can build an image from it with:

    $ docker build -t data-covid19-sfbayarea .

And then run it via:

    # Get a bash prompt inside the container:
    $ docker run -it data-covid19-sfbayarea

    # Or instead just run the scraper in the
    # container and quit the container when the
    # scraper finishes:
    $ docker run -it data-covid19-sfbayarea python scraper_data.py --more args --here

@ldtcooper does this work for you? It might be better to test with the news scraper, since it seems like some of the data scrapers are broken at the moment.