### PR TITLE
Output news results to STDOUT correctly

### DIFF
--- a/scraper_news.py
+++ b/scraper_news.py
@@ -68,7 +68,7 @@ def main(counties: Tuple[str], from_: datetime, format: str, output: str) -> Non
                 with parent.joinpath(f'{county}{extension}').open('wb') as f:
                     f.write(data)
             else:
-                print(data)
+                click.echo(data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Back in #95, I started making all the news serializers output bytes instead of strings. However, we still used `print()` to output the results on STDOUT, and in Python 3, `print()` no longer handles bytes like strings. That made our STDOUT output no longer parseable as JSON (or RSS, or whatever). (I missed this because we always output to files instead of STDOUT in production.) Click's `echo()` function supports bytes, so use that instead.