### PR TITLE
Load more news from Solano via fancy XHR endpoint

### DIFF
--- a/covid19_sfbayarea/news/base.py
+++ b/covid19_sfbayarea/news/base.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import requests
-from typing import Dict, List
+from typing import Dict, List, Optional
 from .feed import NewsFeed, NewsItem
 from .utils import decode_html_body
 
@@ -20,8 +20,15 @@ class NewsScraper:
     scraping should start, then implement `parse_page()`, which returns a list
     of news items given some HTML.
     """
+
+    # Arguments used when creating a `NewsFeed` instance for the county.
     FEED_INFO: Dict = {}
+
+    # Initial URL to load and parse for news.
     URL = ''
+
+    # Default encoding to use when parsing the page, if none could be detected.
+    ENCODING: Optional[str] = None
 
     def __init__(self, from_date: datetime = None, to_date: datetime = None) -> None:
         self.from_date = from_date
@@ -57,7 +64,7 @@ class NewsScraper:
     def load_html(self, url: str) -> str:
         response = requests.get(self.URL)
         response.raise_for_status()
-        return decode_html_body(response)
+        return decode_html_body(response, self.ENCODING)
 
     def parse_page(self, html: str, url: str) -> List[NewsItem]:
         raise NotImplementedError()

--- a/covid19_sfbayarea/news/solano.py
+++ b/covid19_sfbayarea/news/solano.py
@@ -42,7 +42,21 @@ class SolanoNews(NewsScraper):
         home_page_url='http://www.solanocounty.com/news/default.asp'
     )
 
-    URL = 'http://www.solanocounty.com/news/default.asp'
+    # The main news page loads a limited number of items, and may not contain
+    # all news from the timeframe we're looking for. Instead of loading it,
+    # this URL gets an HTML snippet containing more items.
+    # Query parameters:
+    # - `cnt` is the number of items to return. We set a reasonably high number
+    #   to try and cover up to a few months. You can also set `all=1` to return
+    #   all news items, but it is reeeeeaaaaally slow (it can take several
+    #   minutes, or can fail).
+    # - `xml` is an XSL transform to use for formatting the results.
+    #   `mainnews4.xsl` seems to be the same format as the main news page, so
+    #   we can use the same parsing code and easily switch between this and
+    #   the normal news page. `mainnewsN.xsl`, where N is 1-3 also all work,
+    #   and are minor variations on the format.
+    URL = 'http://www.solanocounty.com/custom/0000/aja/news/mainnews.asp?cnt=100&xml=mainnews4.xsl'
+    ENCODING = 'UTF-8'
 
     def parse_page(self, html: str, url: str) -> List[NewsItem]:
         soup = BeautifulSoup(html, 'html5lib')

--- a/covid19_sfbayarea/news/utils.py
+++ b/covid19_sfbayarea/news/utils.py
@@ -162,10 +162,10 @@ def guess_html_encoding(response: requests.Response) -> Optional[str]:
     return encoding
 
 
-def decode_html_body(response: requests.Response) -> str:
-    encoding = guess_html_encoding(response)
-    if encoding:
-        return response.content.decode(encoding, errors='replace')
+def decode_html_body(response: requests.Response, encoding: str = None) -> str:
+    detected_encoding = guess_html_encoding(response) or encoding
+    if detected_encoding:
+        return response.content.decode(detected_encoding, errors='replace')
     else:
         # If we couldn't guess the encoding, let requests do its best.
         return response.text


### PR DESCRIPTION
The main news page for Solano County presents only a limited number of items, and doesn't give us enough to actually cover the full time range we're looking for in a lot of cases. Instead of loading and parsing the main news page, we now load the same endpoint that is used to display the county's full news archives.

NOTE: this required some changes to response body decoding since the endpoint does not specify the encoding it uses. I had to add a way to set a hard-coded fallback encoding when one cannot be inferred from the HTTP response.