### PR TITLE
Let news scrapers fail independently

### DIFF
--- a/covid19_sfbayarea/utils.py
+++ b/covid19_sfbayarea/utils.py
@@ -1,0 +1,6 @@
+def friendly_county(county_id: str) -> str:
+    '''
+    Transform a county ID (e.g. "san_francisco") into a more human-friendly
+    name (e.g. "San Francisco").
+    '''
+    return county_id.replace('_', ' ').title()

--- a/scraper_data.py
+++ b/scraper_data.py
@@ -2,7 +2,9 @@
 import click
 import json
 from covid19_sfbayarea import data as data_scrapers
-from sys import stderr, exit
+from covid19_sfbayarea.utils import friendly_county
+from sys import exit
+import traceback
 from typing import Tuple
 from pathlib import Path
 
@@ -26,9 +28,12 @@ def main(counties: Tuple[str,...], output: str) -> None:
     for county in counties:
         try:
             out[county] = data_scrapers.scrapers[county].get_county()
-        except Exception as e:
+        except Exception as error:
             failed_counties = True
-            print(f'{county} failed to scrape: {e}', file = stderr)
+            message = click.style(f'{friendly_county(county)} county failed',
+                                  fg='red')
+            click.echo(f'{message}: {error}', err=True)
+            traceback.print_exc()
 
     if output:
         parent = Path(output)


### PR DESCRIPTION
This ports the changes to the data scrapers from #118 over to the news scrapers, adds slightly nicer formatting, and includes a stack trace. The main thing is that an exception in any scraper does not stop the others from completing. Output-wise, if the Alameda scraper failed, you'd see something like:

<img width="1068" alt="Screen Shot 2020-09-09 at 8 13 35 PM" src="https://user-images.githubusercontent.com/74178/92680395-99c9f600-f2df-11ea-95dc-4e229d02e513.png">

I added the stack trace in because it seemed like that would be pretty useful information most of the time, but we could also:

- Only show it for errors that aren’t `FutureWarning` or `FormatError` (on the assumption that those errors were expected and are easy to track down, while others are a surprise and the stack would be doubly helpful).
- Add a CLI option to show it, e.g. `--verbose` or `--trace-errors`.
- Add an environment variable to show it, e.g. `TRACE_ERRORS=true`.
- Just strip it back out entirely.