### PR TITLE
Handle stripping whitespace better in Solano news

### DIFF
--- a/covid19_sfbayarea/news/solano.py
+++ b/covid19_sfbayarea/news/solano.py
@@ -5,7 +5,8 @@ from urllib.parse import urljoin
 from .base import NewsScraper
 from .errors import FormatError
 from .feed import NewsItem
-from .utils import get_base_url, is_covid_related, parse_datetime
+from .utils import (get_base_url, is_covid_related, parse_datetime,
+                    normalize_whitespace)
 
 
 SUMMARY_PREFIX_PATTERN = re.compile(r'^SOLANO COUNTY\s*[\-\u2013]\s*', re.I)
@@ -78,7 +79,7 @@ class SolanoNews(NewsScraper):
         else:
             url = urljoin(base_url, url)
 
-        title = title_link.get_text(strip=True)
+        title = normalize_whitespace(title_link.get_text())
         if not title:
             raise FormatError('No title content found')
 
@@ -90,7 +91,7 @@ class SolanoNews(NewsScraper):
         if more_link:
             more_link.extract()
 
-        summary = summary_element.get_text(strip=True)
+        summary = normalize_whitespace(summary_element.get_text())
         summary = SUMMARY_PREFIX_PATTERN.sub('', summary)
 
         return NewsItem(id=url, url=url, title=title, date_published=date,

--- a/covid19_sfbayarea/news/utils.py
+++ b/covid19_sfbayarea/news/utils.py
@@ -10,6 +10,7 @@ from .feed import NewsItem
 
 
 HEADING_PATTERN = re.compile(r'h\d')
+COLLAPSIBLE_WHITESPACE = re.compile(r'[^\S\u00a0]+')
 ISO_DATETIME_PATTERN = re.compile(r'^\d{4}-\d\d-\d\d(T|\s)\d\d:\d\d:\d\d(\.\d+)?(Z|\d{4}|\d\d:\d\d)$')
 US_SHORT_DATE_PATTERN = re.compile(r'^\s*\d+/\d+/\d+\s*$')
 PACIFIC_TIME = dateutil.tz.gettz('America/Los_Angeles')
@@ -179,6 +180,11 @@ def find_with_text(soup: BeautifulSoup, text: str, tag_name: str = None) -> Opti
         return False
 
     return soup.find(match_element)
+
+
+def normalize_whitespace(text: str) -> str:
+    """Normalize the whitespace in a string according to HTML rules."""
+    return COLLAPSIBLE_WHITESPACE.sub(' ', text).strip()
 
 
 def is_covid_related(item: NewsItem) -> bool:


### PR DESCRIPTION
We previously used `element.get_text(strip=True)` when extracting text for Solano news, but that causes real issues when there are child elements (links, bold, etc.) mixed in, because it strips each bit of text independently, leaving us with no spaces at all between words that are at the edge of elements. This handles the whitespace a little better, and more like it normally gets handled in HTML.

Fixes #96.