### PR TITLE
Add tests to validate output format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
 version: 2.1
 
-jobs:
-  lint:
-    docker:
-      - image: circleci/python:3.7
+commands:
+  setup_dependencies:
+    description: "Set Up Dependencies"
     steps:
-      - checkout
       - restore_cache:
           keys:
             - data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
@@ -27,6 +25,14 @@ jobs:
           key: data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - env
+
+jobs:
+  lint:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - setup_dependencies
 
       - run:
           name: Pyflakes
@@ -46,35 +52,19 @@ jobs:
 
   test:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.7-browsers
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - data-covid-19-sfbayarea-v1-{{ arch }}-
-
-      - run:
-          name: Install Dependencies
-          command: |
-            # FIXME: install.sh is currently broken because of a bug in
-            # webdrivermanager. See: https://github.com/rasjani/webdrivermanager/issues/35
-            # For now, do each install step manually.
-            # ./install.sh
-            python3 -m venv env
-            source env/bin/activate
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-
-      - save_cache:
-          key: data-covid-19-sfbayarea-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-          paths:
-            - env
+      - setup_dependencies
 
       - run:
           name: Run Tests
           command: |
             . env/bin/activate
+            # Since we are in CI, run some tests against live websites.
+            # Note that this means some tests on a PR could fail through no
+            # fault of the code changes on that PR.
+            export LIVE_TESTS='*'
             python -m pytest -v .
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ You can run tests using `pytest` like so:
 $ python -m pytest -v .
 ```
 
+Some tests run against live websites and can be slow (or worse; they might spam a county's server with requests and get your IP blocked), so they are disabled by default. To run them, set the `LIVE_TESTS` environment variable. It can be `'*'` to run live tests against all counties, or a comma separated list of counties to test.
+
+```sh
+# Run live tests against all county websites.
+$ LIVE_TESTS='*' python -m pytest -v .
+
+# Run live tests against only San Francisco and Sonoma counties.
+$ LIVE_TESTS='san_francisco,sonoma' python -m pytest -v .
+```
+
 ### Linting and Code Conventions
 
 We use Pyflakes for linting. Many editors have support for running it while you type (either built-in or via a plugin), but you can also run it directly from the command line:

--- a/covid19_sfbayarea/data/san_mateo/cases_by_age.py
+++ b/covid19_sfbayarea/data/san_mateo/cases_by_age.py
@@ -10,4 +10,4 @@ class CasesByAge(PowerBiQuerier):
 
     def _parse_data(self, response_json: Dict[str, List]) -> List[Dict[str, int]]:
         results = super()._parse_data(response_json)
-        return [ { 'group': group, 'count': count } for group, count in results ]
+        return [ { 'group': group, 'raw_count': count } for group, count in results ]

--- a/covid19_sfbayarea/data/san_mateo/cases_by_gender.py
+++ b/covid19_sfbayarea/data/san_mateo/cases_by_gender.py
@@ -8,6 +8,6 @@ class CasesByGender(PowerBiQuerier):
         self.property = 'sex'
         super().__init__()
 
-    def _parse_data(self, response_json: Dict[str, List]) -> List[Dict[str, int]]:
+    def _parse_data(self, response_json: Dict[str, List]) -> Dict[str, int]:
         results = super()._parse_data(response_json)
-        return [ { gender.lower(): count } for gender, count in results ]
+        return { gender.lower(): count for gender, count in results }

--- a/covid19_sfbayarea/data/san_mateo/deaths_by_age.py
+++ b/covid19_sfbayarea/data/san_mateo/deaths_by_age.py
@@ -10,4 +10,4 @@ class DeathsByAge(PowerBiQuerier):
 
     def _parse_data(self, response_json: Dict[str, List]) -> List[Dict[str, int]]:
         results = super()._parse_data(response_json)
-        return [ { 'group': group, 'count': count } for group, count in results ]
+        return [ { 'group': group, 'raw_count': count } for group, count in results ]

--- a/covid19_sfbayarea/data/san_mateo/deaths_by_gender.py
+++ b/covid19_sfbayarea/data/san_mateo/deaths_by_gender.py
@@ -9,6 +9,6 @@ class DeathsByGender(PowerBiQuerier):
         self.property = 'sex'
         super().__init__()
 
-    def _parse_data(self, response_json: Dict[str, List]) -> List[Dict[str, int]]:
+    def _parse_data(self, response_json: Dict[str, List]) -> Dict[str, int]:
         results = super()._parse_data(response_json)
-        return [ { gender.lower(): count } for gender, count in results ]
+        return { gender.lower(): count for gender, count in results }

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -44,7 +44,7 @@ def row_list_to_dict(row: List[str], headers: List[str]) -> UnformattedSeriesIte
 
 def parse_table(tag: element.Tag) -> UnformattedSeries:
     """
-    Takes in a BeautifulSoup table tag and returns a list of dictionaries 
+    Takes in a BeautifulSoup table tag and returns a list of dictionaries
     where the keys correspond to header names and the values to corresponding cell values
     """
     rows = tag.find_all('tr')
@@ -56,7 +56,7 @@ def parse_table(tag: element.Tag) -> UnformattedSeries:
 
 def parse_int(text: str) -> int:
     """
-    Takes in a number in string form and returns that string in integer form 
+    Takes in a number in string form and returns that string in integer form
     and handles zeroes represented as dashes
     """
     text = text.strip()
@@ -203,7 +203,7 @@ def transform_race_eth(race_eth_tag: element.Tag) -> Dict[str, int]:
         'Multi-Race': 'Multiple_Race',
         'Black / African American, non-Hispanic': 'African_Amer',
         'Unknown': 'Unknown'
-    }    
+    }
 
     rows = parse_table(race_eth_tag)
     for row in rows:
@@ -238,7 +238,7 @@ def get_county() -> Dict:
     model = {
         'name': 'Sonoma County',
         'update_time': generate_update_time(sonoma_soup),
-        'source': url,
+        'source_url': url,
         'meta_from_source': get_source_meta(sonoma_soup),
         'meta_from_baypd': '',
         'series': transform_cases(hist_cases),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 mypy==0.770
 pyflakes==2.2.0
 pytest==5.4.3
+pytest-voluptuous==1.2.0

--- a/tests/data/test_valid_output.py
+++ b/tests/data/test_valid_output.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from pytest_voluptuous import S, Partial, Exact
 from typing import List
-from voluptuous.validators import Date, Datetime, Url
+from voluptuous.validators import Date, Match, Url
 from voluptuous.schema_builder import Optional
 import warnings
 
@@ -32,7 +32,7 @@ elif LIVE_TESTS:
 # A validator for an ISO 8601 datetime. This is really similar to
 # voluptuous.validators.Datetime, but it accepts time zone offsets (e.g.
 # `+0300`) instead of just `Z` (the short-form version of `+0000`).
-DatetimeIso = Datetime('%Y-%m-%dT%H:%M:%S.%f%z')
+DatetimeIso = Match(r'^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(.\d+)?(Z|[+\-]\d\d:?\d\d)$')
 
 
 @pytest.mark.parametrize('county', TEST_COUNTIES)

--- a/tests/data/test_valid_output.py
+++ b/tests/data/test_valid_output.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from pytest_voluptuous import S, Partial, Exact
 from typing import List
-from voluptuous.validators import Date, Match, Url
+from voluptuous.validators import Date, Datetime, Url
 from voluptuous.schema_builder import Optional
 import warnings
 
@@ -32,7 +32,7 @@ elif LIVE_TESTS:
 # A validator for an ISO 8601 datetime. This is really similar to
 # voluptuous.validators.Datetime, but it accepts time zone offsets (e.g.
 # `+0300`) instead of just `Z` (the short-form version of `+0000`).
-DatetimeIso = Match(r'^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(.\d+)?(Z|[+\-]\d\d:?\d\d)$')
+DatetimeIso = Datetime('%Y-%m-%dT%H:%M:%S.%f%z')
 
 
 @pytest.mark.parametrize('county', TEST_COUNTIES)

--- a/tests/data/test_valid_output.py
+++ b/tests/data/test_valid_output.py
@@ -1,0 +1,100 @@
+from covid19_sfbayarea.data import scrapers
+from numbers import Number
+import os
+import pytest
+from pytest_voluptuous import S, Partial, Exact
+from typing import List
+from voluptuous.validators import Date, Match, Url
+from voluptuous.schema_builder import Optional
+import warnings
+
+
+# These tests only run if the environment variable `LIVE_TESTS` is set.
+# The value should be `*` to test all scrapers:
+#
+#    $ LIVE_TESTS='*' python -m pytest -v .
+#
+# Or a comma-separated list to test only particular scrapers, e.g:
+#
+#    $ LIVE_TESTS='alameda,san_francisco' python -m pytest -v .
+#
+LIVE_TESTS = os.getenv('LIVE_TESTS', '').lower().strip()
+TEST_COUNTIES: List[str] = []
+if LIVE_TESTS in ('1', 't', 'true', '*', 'all'):
+    TEST_COUNTIES = list(scrapers.keys())
+elif LIVE_TESTS:
+    TEST_COUNTIES = [county
+                     for county in (county.strip()
+                                    for county in LIVE_TESTS.split(','))
+                     if county]
+
+
+# A validator for an ISO 8601 datetime. This is really similar to
+# voluptuous.validators.Datetime, but it accepts time zone offsets (e.g.
+# `+0300`) instead of just `Z` (the short-form version of `+0000`).
+DatetimeIso = Match(r'^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(.\d+)?(Z|[+\-]\d\d:?\d\d)$')
+
+
+@pytest.mark.parametrize('county', TEST_COUNTIES)
+def test_scraper_output_format_is_valid(county: str) -> None:
+    if county not in scrapers:
+        pytest.fail(f'Unknown county: "{county}"')
+    try:
+        result = scrapers[county].get_county()
+    except Exception as error:
+        message = (f'Cannot validate "{county}" format because it failed to '
+                   f'scrape: {error}')
+        warnings.warn(message)
+        pytest.skip(message)
+        return
+
+    # All the totals sections have basically the same schema.
+    totals_section = Partial({
+        Optional('gender'): Exact({
+            # Gender must always at least have male and female.
+            'male': int,
+            'female': int,
+            # Any remaining values should be integers.
+            Optional(str): int
+        }),
+        Optional('age_group'): [Exact({
+            'group': str,
+            'raw_count': int
+        })],
+        Optional('race_eth'): Exact({
+            # We have some mostly-standard keys, but not all scrapers/data
+            # sources conform to them. Just validate that values are integers.
+            str: int
+        }),
+        Optional('transmission_cat'): Exact({
+            # The keys here are not standardized.
+            str: int
+        })
+    })
+
+    assert S({
+        'name': str,
+        'update_time': DatetimeIso,
+        'source_url': Url,
+        'meta_from_source': str,
+        'meta_from_baypd': str,
+        'series': Exact({
+            'cases': [Exact({
+                'date': Date(),
+                Optional('cases'): int,
+                Optional('cumul_cases'): int
+            })],
+            'deaths': [Exact({
+                'date': Date(),
+                Optional('deaths'): int,
+                Optional('cumul_deaths'): int
+            })],
+            Optional('tests'): [Partial({
+                'date': Date(),
+                str: Number
+            })]
+        }),
+        'case_totals': totals_section,
+        Optional('death_totals'): totals_section,
+        Optional('population_totals'): totals_section
+    }) <= result


### PR DESCRIPTION
It turns out several of our scrapers don't quite conform to the data model. We should probably have some classes that model the data and can enforce some formatting and validation, but it's also good to test that the final result adheres to a schema, which is what this does.

Because it's tough to mock responses in Selenium, these tests run against live county websites right now. That can make them pretty slow or intense to run, so this class of tests is disabled by default and you have to opt-in to run them (in CI, we opt-in). To do so, set the `LIVE_TESTS` environment variable to `*` to run all live tests, or set it to a comma-separated list of county names to run just those counties:

    # Run live tests against all county websites.
    $ LIVE_TESTS='*' python -m pytest -v .

    # Run live tests against only San Francisco and Sonoma counties.
    $ LIVE_TESTS='san_francisco,sonoma' python -m pytest -v .

Finally, **these tests skip any county that raises an error while scraping.** Because changes on county websites frequently cause scrapers to fail, we don’t want that to create flaky, failure-prone tests here. (For example, if Alameda and Solano are both failing, we don’t want to be bothered with Alameda errors on the tests for the PR that fixes Solano.)

The validations use [Voluptuous](https://github.com/alecthomas/voluptuous), which is a reasonably nice and concise language for writing schemas. A more verbose, but more standard alternative might be to use JSONSchema.

Tests will now output useful information about what’s wrong with the output data format. For example, in San Mateo:

```
________________ test_scraper_output_format_is_valid[san_mateo] ________________

...
(Lines from test here)
...

E       AssertionError: assert failed due to validation error(s):
E         - case_totals.gender: expected a dictionary (actual: [{'female': 4682}, {'male': 4646}, {'other': 1}, {'unknown': 3}])
E         - case_totals.age_group.0.count: extra keys not allowed (actual: 507)
E         - case_totals.age_group.0.raw_count: required key not provided
E         - death_totals.gender: expected a dictionary (actual: [{'female': 71}, {'male': 71}])
E         - death_totals.age_group.0.count: extra keys not allowed (actual: 0)
E         - death_totals.age_group.0.raw_count: required key not provided
```

Or Marin:

```
__________________ test_scraper_output_format_is_valid[marin] __________________

...
(Lines from test here)
...

E       assert failed due to validation error(s):
E         - update_time: does not match regular expression (actual: '2020-09-19T08:53:43.142176')
E         - meta_from_source: expected str (actual: (['COVID-19 testing and case data are reported as timely, accurately, and...
```

For a complete example, see this test run: https://app.circleci.com/pipelines/github/sfbrigade/data-covid19-sfbayarea/385/workflows/a57acb5d-6858-47b6-b84b-f0b8b5578b4f/jobs/549