### PR TITLE
Raise an error if there's no news in Contra Costa

### DIFF
--- a/covid19_sfbayarea/news/contra_costa.py
+++ b/covid19_sfbayarea/news/contra_costa.py
@@ -103,7 +103,7 @@ class ContraCostaNews(NewsScraper):
 
         # TODO: Figure this one out! It's possible this could be as simple as
         # using an actual browser (e.g. Selenium) instead of requests.
-        if len(news) == 0:
+        if not news:
             raise FormatError('News page had no recognizable news items '
                               '(The Contra Costa site returns an empty page '
                               'every so often; waiting a bit and retrying '

--- a/covid19_sfbayarea/news/contra_costa.py
+++ b/covid19_sfbayarea/news/contra_costa.py
@@ -101,6 +101,14 @@ class ContraCostaNews(NewsScraper):
                 if item:
                     news.append(item)
 
+        # TODO: Figure this one out! It's possible this could be as simple as
+        # using an actual browser (e.g. Selenium) instead of requests.
+        if len(news) == 0:
+            raise FormatError('News page had no recognizable news items '
+                              '(The Contra Costa site returns an empty page '
+                              'every so often; waiting a bit and retrying '
+                              'often works.)')
+
         return news
 
     def parse_article(self, index: int, article: element.Tag,


### PR DESCRIPTION
The Contra Costa county news page occasionally returns en empty page with no news content, resulting in bad PRs like this one: https://github.com/sfbrigade/stop-covid19-sfbayarea/pull/421

This doesn't solve the core problem with Contra Costa's page, but it raises an error if there's no news, which will result in output for other counties and no changes to Contra Costa. A failure with notification is much better than bad output.

🚨 ~**This depends on sfbrigade/stop-covid19-sfbayarea#426 so that the workflow running this scraper only fails if _all_ scrapers fail.** This is similar to [the data v2 workflow](https://github.com/sfbrigade/stop-covid19-sfbayarea/blob/dd3f5d55e570ed7c7d0c3366cd59d537eca7bf1e/.github/workflows/data_update_v2.yml#L62-L68).~ 🚨 (Update: the updates needed on the front-end side have been merged, so nothing is blocking this.)