### PR TITLE
Fix date prefix removal in San Mateo news

### DIFF
--- a/covid19_sfbayarea/news/san_mateo.py
+++ b/covid19_sfbayarea/news/san_mateo.py
@@ -9,18 +9,28 @@ from .utils import parse_datetime
 
 SUMMARY_PREFIX_PATTERN = re.compile(r'''
     ^Redwood\sCity             # Redwood city is the county seat, so news items
-                              # are often "sourced" there
-    (,\sCA\w*\.?)?            # Sometimes followed by "CA", "Calif.", etc.
-    \s*                       # Optional spaces around the separator
-    [\-\u00a0\u2010-\u2015]?  # Optional dashes of various kinds as separator
+                               # are often "sourced" there
+    (,\sCA\w*\.?)?             # Sometimes followed by "CA", "Calif.", etc.
+    \s*                        # Optional spaces around the separator
+    [:\-\u00a0\u2010-\u2015]?  # Optional dashes of various kinds as separator
     \s*
 ''', re.IGNORECASE | re.VERBOSE)
 
 # Titles are often prefixed with a date, and we want to remove it.
 DATE_PREFIX_PATTERN = re.compile(r'''
-    ^\w+\s\d+,\s\d+           # Date in format "month, dd, yyyy"
-    \s*                       # Optional spaces around the separator
-    [\-\u00a0\u2010-\u2015]?  # Optional dashes of various kinds as separator
+    ^\w+\.?\s\d+,\s\d+         # Date in format "month, dd, yyyy" (the month
+                               # may be abbreviated, hence the optional '.')
+    \s*                        # Optional spaces around the separator
+    [:\-\u00a0\u2010-\u2015]?  # Optional dashes of various kinds as separator
+    \s*
+''', re.VERBOSE)
+
+DATE_PREFIX_PATTERN_ESPANOL = re.compile(r'''
+    ^\d+\s+(de\s+)?\w+\.?,?\s+(de\s+)?\d+   # Date in format "dd de mm de yyyy"
+                                            # or "dd mm, yyyy"
+    \s*                                     # Optional spaces around separator
+    [:\-\u00a0\u2010-\u2015]?               # Optional dashes of various kinds
+                                            # as separator
     \s*
 ''', re.VERBOSE)
 
@@ -95,6 +105,7 @@ class SanMateoNews(NewsScraper):
         title = item_element.find('title').text.strip()
         # Most titles are prefixed with a date, which is a bit redundant.
         title = DATE_PREFIX_PATTERN.sub('', title)
+        title = DATE_PREFIX_PATTERN_ESPANOL.sub('', title)
 
         url = item_element.find('link').text.strip()
         date = parse_datetime(item_element.find('pubDate').text.strip())
@@ -103,11 +114,13 @@ class SanMateoNews(NewsScraper):
         # The <description> element can contain HTML snippets. Since we are
         # translating this to our feed's `summary`, which is plain text, we
         # do some quick-n-dirty HTML parsing.
-        description = item_element.find('description').text.strip()
+        description = (item_element.find('description').text or '').strip()
         description = re.sub(r'<br\s*/?>', '\n', description)
         description = re.sub(r'</?\w+[^>]*>', '', description)
         # Strip meaningless prefixes from the front of the text.
-        description = SUMMARY_PREFIX_PATTERN.sub('', description.strip())
+        description = DATE_PREFIX_PATTERN.sub('', description.strip())
+        description = DATE_PREFIX_PATTERN_ESPANOL.sub('', description)
+        description = SUMMARY_PREFIX_PATTERN.sub('', description)
 
         # NOTE: it looks like San Mateo doesn't use <category>, but if we make
         # this more generic, it'd be smart to add parsing for it.

--- a/tests/news/san_mateo_test.py
+++ b/tests/news/san_mateo_test.py
@@ -1,0 +1,109 @@
+from covid19_sfbayarea.news.san_mateo import SanMateoNews
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+
+def test_parses_news_data() -> None:
+    mock_rss = """
+    <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <channel>
+            <item>
+                <title>Sept. 25, 2020: Health Officer Order Prohibits Removal</title>
+                <link>https://cmo.smcgov.org/press-release/sept-25-2020-health-officer-order-prohibits-removal-fire-debris-burn-sites-pending</link>
+                <description><![CDATA[Sept. 25, 2020San Mateo County Health Officer Dr. Scott Morrow has issued a health order.]]></description>
+                <pubDate>Fri, 25 Sep 2020 22:05:08 +0000</pubDate>
+                <dc:creator>mwilson</dc:creator>
+                <guid isPermaLink="false">12711 at https://cmo.smcgov.org</guid>
+            </item>
+        </channel>
+    </rss>
+    """.encode('utf-8')
+
+    scraper = SanMateoNews()
+    items = scraper.parse_feed(mock_rss, SanMateoNews.URL)
+    assert 1 == len(items)
+    assert 'Health Officer Order Prohibits Removal' == items[0].title
+    assert ('San Mateo County Health Officer Dr. Scott Morrow has issued a '
+            'health order.' == items[0].summary)
+    assert (datetime(2020, 9, 25, 22, 5, 8, tzinfo=timezone.utc)
+            == items[0].date_published)
+    assert ('https://cmo.smcgov.org/press-release/sept-25-2020-health-officer-order-prohibits-removal-fire-debris-burn-sites-pending'
+            == items[0].url)
+
+
+def test_strips_non_abbreviated_prefixes_from_title() -> None:
+    mock_rss = """
+    <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <channel>
+            <item>
+                <title>September 25, 2020: Health Officer Order Prohibits Removal</title>
+                <link>https://cmo.smcgov.org/press-release/sept-25-2020-health-officer-order-prohibits-removal-fire-debris-burn-sites-pending</link>
+                <description><![CDATA[ ]]></description>
+                <pubDate>Fri, 25 Sep 2020 22:05:08 +0000</pubDate>
+                <dc:creator>mwilson</dc:creator>
+                <guid isPermaLink="false">12711 at https://cmo.smcgov.org</guid>
+            </item>
+        </channel>
+    </rss>
+    """.encode('utf-8')
+
+    scraper = SanMateoNews()
+    items = scraper.parse_feed(mock_rss, SanMateoNews.URL)
+    assert 1 == len(items)
+    assert 'Health Officer Order Prohibits Removal' == items[0].title
+
+
+def test_strips_prefixes_from_spanish_title_and_summary() -> None:
+    mock_rss = """
+    <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <channel>
+            <item>
+                <title>17 de septiembre de 2020: ¿Qué es necesario para pasar de morado a rojo?</title>
+                <link>https://cmo.smcgov.org/press-release/17-de-septiembre-de-2020-%C2%BFqu%C3%A9-es-necesario-para-pasar-de-morado-rojo</link>
+                <description><![CDATA[17 de septiembre de 2020Cualqier resumen.]]></description>
+                <pubDate>Sat, 19 Sep 2020 16:14:15 +0000</pubDate>
+                <dc:creator>mwilson</dc:creator>
+                <guid isPermaLink="false">12656 at https://cmo.smcgov.org</guid>
+            </item>
+        </channel>
+    </rss>
+    """.encode('utf-8')
+
+    scraper = SanMateoNews()
+    items = scraper.parse_feed(mock_rss, SanMateoNews.URL)
+    assert 1 == len(items)
+    assert '¿Qué es necesario para pasar de morado a rojo?' == items[0].title
+    assert 'Cualqier resumen.' == items[0].summary
+
+
+def test_drops_news_older_than_from_date() -> None:
+    mock_rss = """
+    <rss version="2.0">
+        <channel>
+            <item>
+                <title>This item should be kept</title>
+                <link>https://cmo.smcgov.org/press-release/sept-25-2020-health</link>
+                <description> </description>
+                <pubDate>Fri, 25 Sep 2020 22:05:08 +0000</pubDate>
+                <guid isPermaLink="false">2</guid>
+            </item>
+            <item>
+                <title>This item should NOT be kept</title>
+                <link>https://cmo.smcgov.org/press-release/sept-19-2020-health</link>
+                <description> </description>
+                <pubDate>Fri, 19 Sep 2020 22:05:08 +0000</pubDate>
+                <guid isPermaLink="false">1</guid>
+            </item>
+        </channel>
+    </rss>
+    """.encode('utf-8')
+
+    with patch.object(SanMateoNews, 'load_xml', return_value=mock_rss):
+        scraper = SanMateoNews(
+            from_date=datetime(2020, 9, 20, tzinfo=timezone.utc)
+        )
+        feed = scraper.scrape()
+
+    print(feed.items)
+    assert 1 == len(feed.items)
+    assert '2' == feed.items[0].id


### PR DESCRIPTION
Fixes #134.

Many news items have their title prefixed with a date in San Mateo, which can be a bit confusing and redundant, especially when we normally display the date right before the title at https://panda.baybrigades.org.

<img width="623" alt="Screen Shot 2020-09-24 at 10 00 37 PM" src="https://user-images.githubusercontent.com/74178/94329660-e6653080-ff71-11ea-9c6f-37955d6f744d.png">

To alleviate this, we attempt to remove the date at the start of the title. However, the county recently changed its date format to include abbreviations, which we didn't previously account for. It also turns out that dates are getting formatted differently in Spanish (Chinese articles seem to have no date prefix, and I don't have examples of any other languages to test).

Additionally, it turns out news items with summaries have a similar date prefix on the summary, too! We now remove it as well.

Finally, I added some tests for the San Mateo scraper here. Obviously these won’t help us if the San Mateo source data changes, so these work more to help make sure nothing gets accidentally screwed up when someone is fixing another bug or refactoring something. (And any time the format of San Mateo’s source data changes, the mocks in these tests will also need to be updated.)