### PR TITLE
HOTFIX: Handle messy links in Alameda news titles

### DIFF
--- a/covid19_sfbayarea/news/alameda.py
+++ b/covid19_sfbayarea/news/alameda.py
@@ -13,6 +13,29 @@ from .utils import get_base_url, parse_datetime
 logger = getLogger(__name__)
 
 
+# Maps the various forms of language names in the page's text to ISO language
+# codes so we can determine the language of a link.
+# TODO: Actually use these to handle more than just English links.
+LANGUAGES = {
+    'english': 'en',
+    'spanish': 'es',
+    'español': 'es',
+    'chinese': 'zh_HANS',
+    'chinese (simplified)': 'zh_HANS',   # 'zh_CN' is common, but less correct.
+    'chinese (traditional)': 'zh_HANT',  # 'zh_TW' is common, but less correct.
+    'korean': 'ko',
+    'vietnamese': 'vi',
+    'amharic': 'am',
+    'arabic': 'ar',
+    'farsi': 'fa',
+    'persian': 'fa',
+    'pashto': 'ps',
+    'urdu': 'ur',
+}
+
+LANGUAGE_NAMES = set(name.casefold() for name in LANGUAGES)
+
+
 def date_from_node_text(node: element.Tag) -> Optional[datetime]:
     """
     If an element contains a date as text, return the parsed date.
@@ -109,7 +132,7 @@ class AlamedaNews(NewsScraper):
         if item.url:
             return item
         else:
-            logger.warn('No URL found for news item on %s', item.date_published)
+            logger.warning('No URL found for news item on %s', item.date_published)
             return None
 
 
@@ -326,5 +349,8 @@ class ItemParser:
         Determine if an element looks like a link to a language-specific
         version of the news item.
         """
-        return (node.name == 'a'
-                and len(node.get_text().strip().split(' ')) == 1)
+        if node.name != 'a':
+            return False
+
+        text = node.get_text().strip().casefold()
+        return text in LANGUAGE_NAMES

--- a/tests/news/alameda_test.py
+++ b/tests/news/alameda_test.py
@@ -1,0 +1,66 @@
+from covid19_sfbayarea.news import scrapers
+from covid19_sfbayarea.news.alameda import AlamedaNews
+from covid19_sfbayarea.news.feed import NewsItem
+from covid19_sfbayarea.news.utils import PACIFIC_TIME
+from datetime import datetime
+import os
+import pytest
+from typing import List
+from unittest.mock import patch
+
+
+# Determine whether to run tests that make actual live web requests.
+# See `tests/data/test_valid_output.py` for more explanation.
+# FIXME: create a pytest fixture that centralizes this code and the original
+# version in `tests/data/test_valid_output.py`.
+LIVE_TESTS = os.getenv('LIVE_TESTS', '').lower().strip()
+TEST_COUNTIES: List[str] = []
+if LIVE_TESTS in ('1', 't', 'true', '*', 'all'):
+    TEST_COUNTIES = list(scrapers.keys())
+elif LIVE_TESTS:
+    TEST_COUNTIES = [county
+                     for county in (county.strip()
+                                    for county in LIVE_TESTS.split(','))
+                     if county]
+
+
+@pytest.mark.skipif('alameda' not in TEST_COUNTIES, reason='Live testing not enabled for Alameda county')
+def test_alameda_news() -> None:
+    """Basic test of whether Alameda news works without obvious errors."""
+    feed = AlamedaNews.get_news()
+    assert len(feed.items) > 1
+    for item in feed.items:
+        assert isinstance(item.id, str)
+        assert '' != item.id
+        assert isinstance(item.title, str)
+        assert '' != item.title
+        assert isinstance(item.date_published, datetime)
+        assert item.date_published.tzinfo is not None
+
+
+def test_parses_titles_with_single_word_links() -> None:
+    # This is a stripped-down version of the Alameda page's current markup,
+    # which may change.
+    mock_html = """<!DOCTYPE html>
+        <html>
+            <body>
+                <div id="mainCol">
+                    <strong>September 28, 2020</strong>
+                    Guidance on How to Celebrate Halloween and D<a title="Joint Statement 9/28/2020" href="/covid19-assets/docs/press/joint-statement-2020.09.28.pdf" target="_blank">&iacute;</a>a de los Muertos Safely
+                    <a title="Joint Statement 9/28/2020" href="/covid19-assets/docs/press/joint-statement-2020.09.28.pdf" target="_blank">English</a>
+                    |
+                    <a title="Joint Statement re: Halloween &amp; Dia de los Muertos" href="/covid19-assets/docs/press/joint-health-officer-statement-about-reopening-spa-2020.09.28.pdf" target="_blank">Spanish</a>
+                </div>
+            </body>
+        </html>
+    """
+    with patch.object(AlamedaNews, 'load_html', return_value=mock_html):
+        feed = AlamedaNews.get_news()
+        assert 1 == len(feed.items)
+        assert NewsItem(
+            id='https://covid-19.acgov.org/covid19-assets/docs/press/joint-statement-2020.09.28.pdf',
+            url='https://covid-19.acgov.org/covid19-assets/docs/press/joint-statement-2020.09.28.pdf',
+            title='Guidance on How to Celebrate Halloween and Día de los Muertos Safely',
+            date_published=datetime(2020, 9, 28, tzinfo=PACIFIC_TIME),
+            summary=''
+        ) == feed.items[0]


### PR DESCRIPTION
The Alameda news page now has links that take up only part of the title. The parser sometimes identifies these as links to language-specific versions of the news item, which causes it to stop parsing the title and start looking for language links. However, these links aren't language links, and we need to continue parsing the title as we move through them.

For example, the Alameda news page currently has this entry:

<img width="988" alt="Screen Shot 2020-10-09 at 9 31 01 AM" src="https://user-images.githubusercontent.com/74178/95642254-322cd500-0a5c-11eb-8cb3-0504500663d2.png">

…which was causing us to output the title:

> Guidance on How to Celebrate Halloween and D

…instead of:

> Guidance on How to Celebrate Halloween and Día de los Muertos Safely

This fixes the issue by being *much* more specific about what we expect for the text of a language link. This may have issues if there are ever typos in the language names, but seems to work well enough.

Fixes #140.