### PR TITLE
Sonoma news: handle whitespace in tags correctly

### DIFF
--- a/covid19_sfbayarea/news/sonoma.py
+++ b/covid19_sfbayarea/news/sonoma.py
@@ -4,7 +4,8 @@ from urllib.parse import urljoin
 from .base import NewsScraper
 from .errors import FormatError
 from .feed import NewsItem
-from .utils import get_base_url, is_covid_related, parse_datetime
+from .utils import (get_base_url, is_covid_related, normalize_whitespace,
+                    parse_datetime)
 
 
 class SonomaNews(NewsScraper):
@@ -86,7 +87,7 @@ class SonomaNews(NewsScraper):
         tags = []
         source_element = item_element.select_one('.source')
         if source_element:
-            tags.append(source_element.get_text(strip=True))
+            tags.append(normalize_whitespace(source_element.get_text()))
 
         return NewsItem(id=url, url=url, title=title, date_published=date,
                         summary=summary, tags=tags)


### PR DESCRIPTION
Some of the HTML elements we transform into tags for news items in Sonoma County have line breaks in them, and they weren't being handled well. We already have tools for doing this better, but we just weren't using them. This switches over to them.

For example, in this PR: https://github.com/sfbrigade/stop-covid19-sfbayarea/pull/497

We have a news item like:

```js
{
  "title": "COVID-19 Rental Assistance\u00a0For Sonoma County Renters and Landlords",
  "date_published": "2020-10-14T00:00:00-07:00",
  ...
  "tags": [
    "Sonoma CountyCommunity Development Commission"
  ]
}
```

But it should really be:

```js
{
  "title": "COVID-19 Rental Assistance\u00a0For Sonoma County Renters and Landlords",
  "date_published": "2020-10-14T00:00:00-07:00",
  ...
  "tags": [
    "Sonoma County Community Development Commission"
  ]
}
```

You can test this by running `python scraper_news.py sonoma` and checking the output.