### PR TITLE
HOTFIX: Ensure news items are unique

### DIFF
--- a/covid19_sfbayarea/news/feed.py
+++ b/covid19_sfbayarea/news/feed.py
@@ -92,7 +92,9 @@ class NewsFeed:
     items: List[NewsItem] = field(default_factory=list, init=False)
 
     def append(self, *items: NewsItem) -> None:
-        self.items.extend(items)
+        for item in items:
+            if item not in self.items:
+                self.items.append(item)
         self.sort_items()
 
     def sort_items(self) -> None:

--- a/tests/news/feed_test.py
+++ b/tests/news/feed_test.py
@@ -1,3 +1,4 @@
+from copy import copy
 from covid19_sfbayarea.news.feed import NewsFeed, NewsItem
 from datetime import datetime, timezone
 
@@ -31,3 +32,19 @@ def test_feed_items_sort_stable() -> None:
     feed2 = NewsFeed(title='Test Feed 2')
     feed2.append(b, a)
     assert feed.items == [b, a]
+
+
+def test_feed_items_are_unique() -> None:
+    a = NewsItem(id='a', title='a', url='a',
+                 date_published=datetime(2020, 6, 3, tzinfo=timezone.utc))
+    b = NewsItem(id='b', title='b', url='b',
+                 date_published=datetime(2020, 6, 2, tzinfo=timezone.utc))
+    # It's important that this is a copy, so `a == c`, but `a is not c`
+    c = copy(a)
+
+    feed = NewsFeed(title='Test Feed')
+    feed.append(a, b, c)
+    assert [a, b] == feed.items
+
+    feed.append(c)
+    assert [a, b] == feed.items


### PR DESCRIPTION
Napa county's website is currently repeating each news item 33 times (!), so we are, too:

<img width="600" alt="Screen Shot 2020-10-18 at 11 15 11 AM" src="https://user-images.githubusercontent.com/74178/96378010-21581f80-113e-11eb-9371-7cda36782a70.png">

While this isn't necessarily our fault, we could easily handle this by deduping news items when we add them to the feed.

You can test this by running:

```sh
$ ./run_scraper_news.sh napa
# Or:
$ python scraper_news.py napa
```

And making sure each item in the output is only shown once.