### PR TITLE
Do capture unknown age for Alameda

### DIFF
--- a/covid19_sfbayarea/data/alameda/cases_by_age.py
+++ b/covid19_sfbayarea/data/alameda/cases_by_age.py
@@ -10,7 +10,7 @@ class CasesByAge(PowerBiQuerier):
 
     def _parse_data(self, response_json: Dict[str, List]) -> List[Dict[str, int]]:
         results = super()._parse_data(response_json)
-        return [ { 'group': group, 'raw_count': count } for group, count in results if group != 'Unknown Age' ]
+        return [ { 'group': group, 'raw_count': count } for group, count in results ]
 
     def _select(self) -> List[Dict[str, Any]]:
         property = 'NumberOfCases'

--- a/covid19_sfbayarea/data/alameda/deaths_by_age.py
+++ b/covid19_sfbayarea/data/alameda/deaths_by_age.py
@@ -10,7 +10,7 @@ class DeathsByAge(PowerBiQuerier):
 
     def _parse_data(self, response_json: Dict[str, List]) -> List[Dict[str, int]]:
         results = super()._parse_data(response_json)
-        return [ { 'group': group, 'raw_count': count } for group, count in results if group != 'Unknown Age' ]
+        return [ { 'group': group, 'raw_count': count } for group, count in results ]
 
     def _select(self) -> List[Dict[str, Any]]:
         property = 'NumberOfDeaths'


### PR DESCRIPTION
Per conversation with the team, we don't want to hide the Unknown Age. We already show this for San Mateo County, we should do it here too.

Closes https://github.com/sfbrigade/data-covid19-sfbayarea/issues/147