### PR TITLE
Improve error messaging for changed keys in Sonoma County

### DIFF
--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -127,11 +127,12 @@ def transform_transmission(transmission_tag: element.Tag) -> Dict[str, int]:
     rows = parse_table(transmission_tag)
     # turns the transmission categories on the page into the ones we're using
     transmission_type_conversion = {'Community': 'community', 'Close Contact': 'from_contact', 'Travel': 'travel', 'Under Investigation': 'unknown'}
+    assert_equal_sets(transmission_type_conversion.keys(),
+                      (row['Source'] for row in rows),
+                      description='Transmission types')
     for row in rows:
         type = row['Source']
         number = parse_int(row['Cases'])
-        if type not in transmission_type_conversion:
-            raise FormatError(f'The transmission type {type} was not found in transmission_type_conversion')
         type = transmission_type_conversion[type]
         transmissions[type] = number
     return transmissions
@@ -157,11 +158,12 @@ def transform_gender(tag: element.Tag) -> Dict[str, int]:
     genders = {}
     rows = parse_table(tag)
     gender_string_conversions = {'Males': 'male', 'Females': 'female'}
+    assert_equal_sets(gender_string_conversions.keys(),
+                      (row['Gender'] for row in rows),
+                      description='Genders')
     for row in rows:
         gender = row['Gender']
         cases = parse_int(row['Cases'])
-        if gender not in gender_string_conversions:
-            raise FormatError('An unrecognized gender has been added to the gender table')
         genders[gender_string_conversions[gender]] = cases
     return genders
 

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -4,6 +4,7 @@ import dateutil.parser
 from typing import List, Dict, Union
 from bs4 import BeautifulSoup, element # type: ignore
 from ..errors import FormatError
+from ..utils import assert_equal_sets
 
 TimeSeriesItem = Dict[str, Union[str, int]]
 TimeSeries = List[TimeSeriesItem]
@@ -208,14 +209,17 @@ def transform_race_eth(race_eth_tag: element.Tag) -> Dict[str, int]:
     }
 
     rows = parse_table(race_eth_tag)
+    assert_equal_sets(race_transform.keys(),
+                      (row['Race/Ethnicity'] for row in rows),
+                      description='Racial groups')
+
     for row in rows:
         group_name = row['Race/Ethnicity']
         cases = parse_int(row['Cases'])
-        if group_name not in race_transform:
-            raise FormatError(f'The racial group {group_name} is new in the data -- please adjust the scraper accordingly')
         internal_name = race_transform[group_name]
         race_cases[internal_name] = cases
     return race_cases
+
 
 def get_table_tags(soup: BeautifulSoup) -> List[element.Tag]:
     """

--- a/covid19_sfbayarea/utils.py
+++ b/covid19_sfbayarea/utils.py
@@ -3,12 +3,14 @@ import dateutil.tz
 import re
 from datetime import datetime, tzinfo
 from functools import reduce
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
+from .errors import FormatError
 
 
 US_SHORT_DATE_PATTERN = re.compile(r'^\s*\d+/\d+/\d+\s*$')
 PACIFIC_TIME = dateutil.tz.gettz('America/Los_Angeles')
 CURRENT_YEAR = datetime.utcnow().year
+
 
 def friendly_county(county_id: str) -> str:
     '''
@@ -46,3 +48,17 @@ def parse_datetime(date_string: str, timezone: Optional[tzinfo] = PACIFIC_TIME) 
         raise ValueError(f'Unknown date format: "{date_string}"')
 
     return date
+
+
+def assert_equal_sets(a: Iterable, b: Iterable, description: str = 'items') -> None:
+    """
+    Raise a nicely formatted exception if the two arguments do not contain the
+    same items. Arguments can be any iterable; the order of items in them does
+    not matter (they are treated like sets).
+    """
+    a_set = isinstance(a, set) and a or set(a)
+    b_set = isinstance(b, set) and b or set(b)
+    if a_set != b_set:
+        removed = a_set - b_set
+        added = b_set - a_set
+        raise FormatError(f"{description} are different -- removed: {removed}, added: {added}")

--- a/covid19_sfbayarea/utils.py
+++ b/covid19_sfbayarea/utils.py
@@ -61,4 +61,10 @@ def assert_equal_sets(a: Iterable, b: Iterable, description: str = 'items') -> N
     if a_set != b_set:
         removed = a_set - b_set
         added = b_set - a_set
-        raise FormatError(f"{description} are different -- removed: {removed}, added: {added}")
+        message_parts = [f'{description} are different']
+        if removed:
+            message_parts.append(f'removed {removed}')
+        if added:
+            message_parts.append(f'added {added}')
+
+        raise FormatError(', '.join(message_parts))


### PR DESCRIPTION
~This fixes #154, where the race/ethnicity groups in Sonoma County have been changed.~

It also adds a new tool for ensuring actual and expected group names are the same in all the zillion places we do this across the data scrapers, so we get better info. Instead of an error like:

```
FormatError: The racial group Asian, non-Hispanic is new in the data -- please adjust the scraper accordingly
```

We now get:

```
FormatError: Racial groups are different -- removed: {'Multi-Race', 'Asian / Pacific Islander, non-Hispanic', 'Other', 'Black / African American, non-Hispanic'}, added: {'Asian, non-Hispanic', 'Black/African American, non-Hispanic', 'Native Hawaiian and other Pacific Islander, non-Hispanic', 'American Indian/Alaska Native, non-Hispanic', 'Multi-racial, non-Hispanic'}
```

So you can see all the changes at a glance.

---

*Update Nov. 8: The hotfix-y parts of this have been merged separately, and #154 is already fixed. The commits in this PR have been rewritten to only include the error message changes.*