### PR TITLE
HOTFIX: Add "Other, non-Hispanic" race to Sonoma

### DIFF
--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -203,6 +203,7 @@ def transform_race_eth(race_eth_tag: element.Tag) -> Dict[str, int]:
         'Black/African American, non-Hispanic': 'African_Amer',
         'American Indian/Alaska Native, non-Hispanic': 'Native_Amer',
         'Native Hawaiian and other Pacific Islander, non-Hispanic': 'Pacific_Islander',
+        'Other, non-Hispanic': 'Other',
         'Unknown': 'Unknown',
     }
 


### PR DESCRIPTION
Sonoma county recently added a new race/ethnicity group ("Other, non-Hispanic"), so its scraper needs to be updated to account for it.

**To Test:**

Run `python scraper_data.py sonoma` and make sure it outputs data instead of an error.