### PR TITLE
HOTFIX: Clean up a variety of errors in data scrapers

### DIFF
--- a/covid19_sfbayarea/data/marin.py
+++ b/covid19_sfbayarea/data/marin.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from selenium import webdriver # type: ignore
 
 from ..errors import FormatError
+from ..utils import PERMISSIVE_SPACES
 from ..webdriver import get_firefox
 from .utils import get_data_model
 
@@ -65,7 +66,11 @@ class MarinDashboardPage:
 
     def get_chart_data(self, chart_id: str) -> csv.DictReader:
         "Get the data backing a given chart as a :class:`csv.DictReader`."
-        return csv.DictReader(self.get_chart_csv(chart_id))
+        reader = csv.DictReader(self.get_chart_csv(chart_id))
+        # Clean up field names, which sometimes have erroneous whitespace.
+        reader.fieldnames = [name.strip(PERMISSIVE_SPACES)
+                             for name in reader.fieldnames or []]
+        return reader
 
     def _load(self) -> None:
         self.driver.get(self.url)

--- a/covid19_sfbayarea/data/san_francisco.py
+++ b/covid19_sfbayarea/data/san_francisco.py
@@ -2,6 +2,7 @@
 import json
 from typing import Dict, List
 from collections import Counter
+from ..utils import assert_equal_sets
 from .utils import get_data_model, SocrataApi
 
 def get_county() -> Dict:
@@ -146,12 +147,26 @@ def get_tests_series(session : SocrataApi, resource_ids: Dict[str, str]) -> List
         test_series.append(out_entry)
     return test_series
 
-def get_age_table(session : SocrataApi, resource_ids: Dict[str, str]) -> List[Dict]:
+def get_age_table(session: SocrataApi, resource_ids: Dict[str, str]) -> List[Dict]:
     """Get cases by age"""
     resource_id = resource_ids['age']
     # Dict of target_label:source_label for lookups
-    AGE_KEYS = {"18_and_under": "under 18", "18_to_30": "18-30", "31_to_40": "31-40", "41_to_50": "41-50",
-                "51_to_60": "51-60", "61_to_70": "61-70", "71_to_80": "71-80", "81_and_older": "81+",}
+    AGE_KEYS = {
+        "0_to_4":       "0-4",
+        "5_to_10":      "5-10",
+        "11_to_13":     "11-13",
+        "14_to_17":     "14-17",
+        "18_to_20":     "18-20",
+        "21_to_24":     "21-24",
+        "25_to_29":     "25-29",
+        "30_to_39":     "30-39",
+        "40_to_49":     "40-49",
+        "50_to_59":     "50-59",
+        "60_to_69":     "60-69",
+        "70_to_79":     "70-79",
+        "80_and_older": "80+",
+        "unknown":      "Unknown",
+    }
 
     # find the latest date of data collection
     params = {'$select': 'max(specimen_collection_date) as date'}
@@ -162,9 +177,10 @@ def get_age_table(session : SocrataApi, resource_ids: Dict[str, str]) -> List[Di
     data = session.resource(resource_id, params=params)
 
     # flatten data into a dictionary of age_group:cases
-    data = { item["age_group"] : int(item["cases"]) for item in data }
+    data = { item["age_group"]: int(item["cases"]) for item in data }
     age_table = []
     # fill in values in age table
+    assert_equal_sets(AGE_KEYS.values(), data.keys())
     for target_key, source_key in AGE_KEYS.items():
         age_table.append( { "group": target_key, "raw_count": data[source_key] })
 
@@ -176,7 +192,14 @@ def get_gender_table(session : SocrataApi, resource_ids: Dict[str, str]) -> Dict
     # Dict of source_label:target_label for re-keying.
     # Note: non cis genders not currently reported
     resource_id = resource_ids['gender']
-    GENDER_KEYS = {"Female": "female", "Male": "male", "Unknown": "unknown", "Trans Female": "female", "Trans Male": "male"}
+    GENDER_KEYS = {
+        "Female": "female",
+        "Male": "male",
+        "Unknown": "unknown",
+        "Trans Female": "female",
+        "Trans Male": "male",
+        "Other": "other"
+    }
     # find the latest date of data collection
     params = {'$select': 'max(specimen_collection_date) as date'}
     latest_date = session.resource(resource_id, params=params)[0]
@@ -186,10 +209,12 @@ def get_gender_table(session : SocrataApi, resource_ids: Dict[str, str]) -> Dict
     data = session.resource(resource_id, params=params)
 
     # re-key
-    table : Dict[str, int]= dict()
+    assert_equal_sets(GENDER_KEYS.keys(), (entry['gender'] for entry in data))
+
+    table: Dict[str, int] = dict()
     for entry in data:
         rekey = GENDER_KEYS[entry['gender']]
-        table[rekey] = table.get(rekey,0) + int(entry["cases"])
+        table[rekey] = table.get(rekey, 0) + int(entry["cases"])
     return table
 
 # Confirmed cases by race and ethnicity
@@ -210,6 +235,7 @@ def get_race_eth_table(session: SocrataApi, resource_ids: Dict[str, str]) -> Dic
     data = session.resource(resource_id, params=params)
     # re-key and aggregate to flatten race x ethnicity
     # initalize all categories to 0 for aggregating
+    assert_equal_sets(RACE_ETH_KEYS.keys(), (item["race_ethnicity"] for item in data))
     race_eth_data: Dict[str, int] = {v: 0 for v in RACE_ETH_KEYS.values()}
 
     for item in data:  # iterate through all race x ethnicity objects

--- a/covid19_sfbayarea/data/san_mateo/time_series_cumulative.py
+++ b/covid19_sfbayarea/data/san_mateo/time_series_cumulative.py
@@ -5,7 +5,7 @@ class TimeSeriesCumulative(PowerBiQuerier):
     def __init__(self) -> None:
         self.source = 'c'
         self.name = 'cases_by_day'
-        self.property = 'date_result'
+        self.property = 'episode_date'
         super().__init__()
 
     def _parse_data(self, response_json: Dict) -> Dict[int, int]:

--- a/covid19_sfbayarea/data/san_mateo/time_series_daily.py
+++ b/covid19_sfbayarea/data/san_mateo/time_series_daily.py
@@ -6,7 +6,7 @@ class TimeSeriesDaily(PowerBiQuerier):
     def __init__(self) -> None:
         self.source = 'c'
         self.name = 'cases_by_day'
-        self.property = 'date_result'
+        self.property = 'episode_date'
         super().__init__()
 
     def _parse_data(self, response_json: Dict) -> Dict[int, int]:

--- a/covid19_sfbayarea/errors.py
+++ b/covid19_sfbayarea/errors.py
@@ -5,3 +5,10 @@ class FormatError(Exception):
     accessing has changed.
     """
     pass
+
+
+class PowerBiQueryError(ValueError):
+    """
+    Represents an error returned by PowerBI in response to a query.
+    """
+    ...

--- a/covid19_sfbayarea/utils.py
+++ b/covid19_sfbayarea/utils.py
@@ -23,9 +23,8 @@ def friendly_county(county_id: str) -> str:
 def dig(items: Union[Dict[Any, Any], List[Any]], json_path: List[Any]) -> Any:
     try:
         return reduce(lambda subitem, next_step: subitem[next_step], json_path, items)
-    except (KeyError, TypeError, IndexError) as err:
-        print('Error reading returned JSON, check path: ', err)
-        raise(err)
+    except (KeyError, TypeError, IndexError) as error:
+        raise KeyError(f'Error reading data at path: {json_path}') from error
 
 
 def parse_datetime(date_string: str, timezone: Optional[tzinfo] = PACIFIC_TIME) -> datetime:

--- a/covid19_sfbayarea/utils.py
+++ b/covid19_sfbayarea/utils.py
@@ -3,6 +3,7 @@ import dateutil.tz
 import re
 from datetime import datetime, tzinfo
 from functools import reduce
+import string
 from typing import Any, Dict, Iterable, List, Optional, Union
 from .errors import FormatError
 
@@ -67,3 +68,32 @@ def assert_equal_sets(a: Iterable, b: Iterable, description: str = 'items') -> N
             message_parts.append(f'added {added}')
 
         raise FormatError(', '.join(message_parts))
+
+
+# A more permissive set of space characters that you might want to remove from
+# a string. We've seen all kinds of crazy invisible space characters embedded
+# where they obviously weren't intended in web pages and that aren't covered by
+# `str.strip()` or by `\s` in regular expressions. Using this instead can help
+# clean those up.
+PERMISSIVE_SPACES = (
+    string.whitespace +
+    '\u00a0'  # No-break space
+    '\ufeff'  # Zero width no-break space
+    '\u2000'  # En quad
+    '\u2001'  # Em quad
+    '\u2002'  # En space
+    '\u2003'  # Em space
+    '\u2004'  # Three-per-em space
+    '\u2005'  # Four-per-em space
+    '\u2006'  # Six-per-em space
+    '\u2007'  # Figure space
+    '\u2008'  # Punctuation space
+    '\u2009'  # Thin space
+    '\u200a'  # Hair space
+    '\u200b'  # Zero width space
+    '\u2028'  # Line separator
+    '\u2029'  # Paragraph separator
+    '\u202f'  # Narrow no-break space
+    '\u205f'  # Medium mathematical space
+    '\u3000'  # Ideographic space
+)

--- a/tests/news/san_mateo_test.py
+++ b/tests/news/san_mateo_test.py
@@ -104,6 +104,5 @@ def test_drops_news_older_than_from_date() -> None:
         )
         feed = scraper.scrape()
 
-    print(feed.items)
     assert 1 == len(feed.items)
     assert '2' == feed.items[0].id


### PR DESCRIPTION
It turns out the scrapers have been failing for a while because of a stray `print()` call, and that failure masked a series of other, further failures from a variety of counties. This attempts to fix them all:

- Clean up a couple stray `print()` calls (this should be all of them). One should not have existed at all, and the other I’ve replaced with a more detailed exception that I think actually does the job better.

- Clean up what appears to be unintentional spaces in Marin county’s table headers.

- Support new genders in San Francisco’s data.

- Support new age groups in San Francisco’s data, and also switch to human-friendly, county defined age groups (we decided to do this for all counties a while back, and this error seemed like a good time to go ahead and do it for SF rather then defining a whole new list of semi-standard age group keys).

- Fix renamed fields in San Mateo’s API. This also adds nicer error handling for PowerBI queries.