### PR TITLE
HOTFIX: Handle strings in Alameda %-positive tests

### DIFF
--- a/covid19_sfbayarea/data/alameda/time_series_tests_percent.py
+++ b/covid19_sfbayarea/data/alameda/time_series_tests_percent.py
@@ -29,3 +29,16 @@ class TimeSeriesTestsPercent(PowerBiQuerier):
             },
             'Version': 1
         }
+
+    def get_data(self) -> List:
+        # The values in this dataset can sometimes be strings. It looks like
+        # PowerBI probably sends strings for values that cannot be represented
+        # by a float64 (since JSON only supports 64-bit floats for numbers).
+        # For example, '7.2322939999999996' gets sent as a string; the closest
+        # float64 representation is '7.232294'.
+        #
+        # For our purposes, the loss of precision here is OK, and we want to do
+        # math with the numbers here, so just convert to a float.
+        data = super().get_data()
+        return [[item[0], float(item[1])] if len(item) > 1 else item
+                for item in data]


### PR DESCRIPTION
For some days in Alameda, we get strings instead of numbers in the percent positive tests timeseries. This fix is not particularly generic, but solves the immediate problem. It looks like PowerBI may try to preserve precision by sending strings when float64 cannot accurately represent a value. We'll have to think about more generic ways to account for this.

Example excerpt from the data:

```json
{
  "results": [
    {
      "result": {
        "data": {
          "dsr": {
            "DS": [
              {
                "PH": [
                  {
                    "DM0": [
                      {"C": [1607644800000, 6.916541]},
                      {"C": [1607731200000, 7.157232]},
                      {"C": [1607817600000, "7.2322939999999996"]},  // Not a number!
                      {"C": [1607904000000, 7.288172]},
                      {"C": [1607990400000, 7.475967]}