### PR TITLE
HOTFIX: handle repeat rows in Solano age groups

### DIFF
--- a/covid19_sfbayarea/data/solano.py
+++ b/covid19_sfbayarea/data/solano.py
@@ -220,21 +220,21 @@ def get_age_table(out: Dict) -> None:
     response2.raise_for_status()
     parsed2 = response2.json()
 
-    # Format the results.
-    age_group_cases = [{
-                        'group': entry['attributes']['Age_group'],
-                        'raw_count': entry['attributes']['AG_Total_cases']
-                       }
-                       for entry in parsed2['features']]
-    age_group_deaths = [{
-                         'group': entry['attributes']['Age_group'],
-                         'raw_count': entry['attributes']['AG_deaths']
-                        }
-                        for entry in parsed2['features']]
+    # Because of the way data is structured (ages, race/ethnicity groups, etc.
+    # all on one line), some categories get repeated (even though the data is
+    # not different). To handle this, create a dict with our groupings to
+    # de-duplicate before formatting final results.
+    age_groups = {entry['attributes']['Age_group']: entry['attributes']
+                  for entry in parsed2['features']}
+
+    age_group_cases = [{'group': group, 'raw_count': data['AG_Total_cases']}
+                       for group, data in age_groups.items()]
+    age_group_deaths = [{'group': group, 'raw_count': data['AG_deaths']}
+                        for group, data in age_groups.items()]
 
     # Validate that we’ve got the right age groups.
     if len(age_group_cases) != 4:
-        raise FormatError(f'Race_eth query did not return 5 groups. Results: {age_group_cases}')
+        raise FormatError(f'Age group query did not return 4 groups. Results: {age_group_cases}')
 
     # save to the out dict
     out["case_totals"]["age_group"] = age_group_cases


### PR DESCRIPTION
The last day of Solano's data seems to be getting repeated in their dataset (every row is repeated once, totally verbatim, as far as I can tell). I'm not sure why that's happening (it's there that way in the source data if you go look on the web), but it seems benign, so I've just added a fix here to de-duplicate the age groups (we just take the last value we have for each group). This already happens naturally for race/ethnicity and gender (since we build dicts instead of lists), so there's no need to fix those.