### PR TITLE
Drop dashes at start of Solano news item summaries

### DIFF
--- a/covid19_sfbayarea/news/solano.py
+++ b/covid19_sfbayarea/news/solano.py
@@ -9,7 +9,8 @@ from .feed import NewsItem
 from .utils import get_base_url, is_covid_related, normalize_whitespace
 
 
-SUMMARY_PREFIX_PATTERN = re.compile(r'^SOLANO COUNTY\s*[\-\u2013]\s*', re.I)
+SUMMARY_PREFIX_PATTERN = re.compile(r'^SOLANO COUNTY\s*[\-\u2010-\u2015]+\s*',
+                                    re.I)
 
 
 class SolanoNews(NewsScraper):


### PR DESCRIPTION
We had some code meant to remove non-useful prefixes on the news summaries from Solano county, but most news items are still coming through with a dash in front anyway:

    {
      "summary": "— Starting Thursday, December 17, 2020 at 11:59 p.m., Solano County will…"
    }

This fixes the regex we use to elimite it:

    {
      "summary": "Starting Thursday, December 17, 2020 at 11:59 p.m., Solano County will…"
    }