### PR TITLE
HOTFIX: Napa all news page is broken

### DIFF
--- a/covid19_sfbayarea/news/napa.py
+++ b/covid19_sfbayarea/news/napa.py
@@ -44,10 +44,14 @@ class NapaNews(NewsScraper):
 
     FEED_INFO = dict(
         title='Napa County COVID-19 News',
-        home_page_url='https://www.countyofnapa.org/CivicAlerts.aspx?sort=date'
+        home_page_url='https://www.countyofnapa.org/CivicAlerts.aspx?CID=7,25,10,9,18&sort=date'
     )
 
-    URL = 'https://www.countyofnapa.org/CivicAlerts.aspx?sort=date'
+    # NOTE: the CID parameter represents the categories to include
+    # (e.g. Sheriff's Office, County Executive, etc.). You can drop this
+    # parameter to get *all* categories, but that is currently causing the page
+    # to break. So we use a list of categories we know is safe. ¯\_(ツ)_/¯
+    URL = 'https://www.countyofnapa.org/CivicAlerts.aspx?CID=7,25,10,9,18&sort=date'
 
     def parse_page(self, html: str, url: str) -> List[NewsItem]:
         soup = BeautifulSoup(html, 'html5lib')


### PR DESCRIPTION
Napa county's page for all news is broken (`https://www.countyofnapa.org/CivicAlerts.aspx?sort=date`) and doesn't load, so we can't actually scrape it. However, if we look at news from only a subset of categories, it works fine (it appears that category 17 [Board of Supervisors] is broken). This lists all the categories except one that breaks, so the page loads and gives us most news.

Test this by running:

```sh
$ python scraper_news.py napa
```

And making sure it outputs some news instead of an error.