### PR TITLE
Fix sonoma data (#178)

### DIFF
--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -125,8 +125,20 @@ def transform_transmission(transmission_tag: element.Tag) -> Dict[str, int]:
     """
     transmissions = {}
     rows = parse_table(transmission_tag)
+
     # turns the transmission categories on the page into the ones we're using
-    transmission_type_conversion = {'Community': 'community', 'Close Contact': 'from_contact', 'Travel': 'travel', 'Under Investigation': 'unknown'}
+    transmission_type_conversion = {
+        'Congregate Care': 'congregate_care',
+        'Health Care': 'health_care',
+        'Household': 'household',
+        'Large Gathering': 'gathering_small',
+        'Other': 'other',
+        'Small Gathering': 'gathering_large',
+        'Travel': 'travel',
+        'Unknown': 'unknown',
+        'Workplace': 'workplace'
+    }
+
     assert_equal_sets(transmission_type_conversion.keys(),
                       (row['Source'] for row in rows),
                       description='Transmission types')

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -121,7 +121,17 @@ def transform_transmission(transmission_tag: element.Tag) -> Dict[str, float]:
     """
     Takes in a BeautifulSoup tag for the transmissions table and breaks it into
     a dictionary of type:
-    {'community': -1, 'from_contact': -1, 'travel': -1, 'unknown': -1}
+    {
+        "household": -1.0,
+        "workplace": -1.0,
+        "congregate_care": -1.0,
+        "gathering_small": -1.0,
+        "health_care": -1.0,
+        "gathering_large": -1.0,
+        "travel": -1.0,
+        "other": -1.0,
+        "unknown": -1.0
+    }
     """
     transmissions = {}
     rows = parse_table(transmission_tag)

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -117,7 +117,7 @@ def transform_cases(cases_tag: element.Tag) -> Dict[str, TimeSeries]:
 
     return { 'cases': cases, 'deaths': deaths }
 
-def transform_transmission(transmission_tag: element.Tag, total_cases: int, how: str = "orig") -> Dict[str, int]:
+def transform_transmission(transmission_tag: element.Tag, total_cases: int, normalize: bool = True) -> Dict[str, int]:
     """
     Takes in a BeautifulSoup tag for the transmissions table and breaks it into
     a dictionary. Fields are either the original from data source or are coerced
@@ -150,7 +150,7 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, how:
         type = transmission_type_conversion[type]
         transmissions[type] = case_count
 
-    if how == "coerce":
+    if normalize:
         # coerce categories into groups consistent with other datasets
         # those groups are "from_contact", "travel", "unknown" and "community"
 
@@ -164,6 +164,8 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, how:
             [transmissions.get(category, 0) for category in transmissions.keys()
              if category in from_contact_categories]
         )
+        if from_contact == 0:
+            from_contact = -1
 
         community_categories = [
             "health_care",
@@ -174,6 +176,8 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, how:
             [transmissions.get(category, 0) for category in transmissions.keys()
              if category in community_categories]
         )
+        if community == 0:
+            community = -1
 
         coerced_transmissions = {}
         coerced_transmissions["from_contact"] = from_contact
@@ -314,8 +318,8 @@ def get_county() -> Dict:
         'meta_from_baypd': '',
         'series': transform_cases(hist_cases),
         'case_totals': {
-            'transmission_cat': transform_transmission(cases_by_source, total_cases, how='coerce'),
-            'transmission_cat_orig': transform_transmission(cases_by_source, total_cases),
+            'transmission_cat': transform_transmission(cases_by_source, total_cases),
+            'transmission_cat_orig': transform_transmission(cases_by_source, total_cases, normalize=False),
             'age_group': transform_age(cases_by_age),
             'race_eth': transform_race_eth(cases_by_race),
             'gender': transform_gender(cases_by_gender)

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -181,15 +181,15 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, norm
         if community == 0:
             community = -1
 
-        coerced_transmissions = {}
-        coerced_transmissions["from_contact"] = from_contact
-        coerced_transmissions["community"] = community
-        coerced_transmissions["travel"] = transmissions.get("travel", -1)
-        coerced_transmissions["unknown"] = transmissions.get("unknown", -1)
+        normalized_transmissions = {}
+        normalized_transmissions["from_contact"] = from_contact
+        normalized_transmissions["community"] = community
+        normalized_transmissions["travel"] = transmissions.get("travel", -1)
+        normalized_transmissions["unknown"] = transmissions.get("unknown", -1)
 
         # check that we have all the math right
-        assert sum(coerced_transmissions.values()) == sum(transmissions.values())
-        transmissions = coerced_transmissions
+        assert sum(normalized_transmissions.values()) == sum(transmissions.values())
+        transmissions = normalized_transmissions
 
     else:
         pass

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -186,8 +186,6 @@ def transform_transmission(
             [transmissions.get(category, 0) for category in transmissions.keys()
              if category in from_contact_categories]
         )
-        if from_contact == 0:
-            from_contact = -1
 
         community_categories = [
             "health_care",
@@ -198,8 +196,6 @@ def transform_transmission(
             [transmissions.get(category, 0) for category in transmissions.keys()
              if category in community_categories]
         )
-        if community == 0:
-            community = -1
 
         normalized_transmissions = {}
         normalized_transmissions["from_contact"] = from_contact

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -120,8 +120,10 @@ def transform_cases(cases_tag: element.Tag) -> Dict[str, TimeSeries]:
 def transform_transmission(transmission_tag: element.Tag, total_cases: int, normalize: bool = True) -> Dict[str, int]:
     """
     Takes in a BeautifulSoup tag for the transmissions table and breaks it into
-    a dictionary. Fields are either the original from data source or are coerced
-    into groups consistent with other datasets, by using `how='coerce` arg
+    a dictionary. Fields are either the original from data source or are normalized
+    into groups consistent with other datasets, by using `normalize=True` (default).
+    Data model:
+      {'community': -1, 'from_contact': -1, 'travel': -1, 'unknown': -1}
     """
     transmissions = {}
     rows = parse_table(transmission_tag)
@@ -151,7 +153,7 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, norm
         transmissions[type] = case_count
 
     if normalize:
-        # coerce categories into groups consistent with other datasets
+        # normalize categories into groups consistent with other datasets
         # those groups are "from_contact", "travel", "unknown" and "community"
 
         from_contact_categories = [

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -68,9 +68,9 @@ def parse_int(text: str) -> int:
 
 def generate_update_time(soup: BeautifulSoup) -> str:
     """
-    Generates a timestamp string (e.g. May 6, 2020 10:00 AM) for when the scraper is run
+    Finds and parses an ISO 8601 timestamp string for when the page was last updated
     """
-    update_time_text = soup.find('time', {'class': 'updated'})['datetime']
+    update_time_text = soup.find('meta', {'property': 'article:modified_time'})['content']
     try:
         date = dateutil.parser.parse(update_time_text)
     except ValueError:

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -140,13 +140,15 @@ def transform_transmission(transmission_tag: element.Tag) -> Dict[str, int]:
     }
 
     assert_equal_sets(transmission_type_conversion.keys(),
-                      (row['Source'] for row in rows),
+                      (row['Exposure Location'] for row in rows),
                       description='Transmission types')
+
     for row in rows:
-        type = row['Source']
-        number = parse_int(row['Cases'])
+        type = row['Exposure Location']
+        percent_cases = round(float(row['All Time'].replace('%', '')), 2)
         type = transmission_type_conversion[type]
-        transmissions[type] = number
+        transmissions[type] = percent_cases
+
     return transmissions
 
 def transform_tests(tests_tag: element.Tag) -> Dict[str, int]:

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -194,8 +194,8 @@ def transform_transmission(
                                 for category in from_contact_categories),
             "community": sum(transmissions[category]
                              for category in community_categories),
-            "travel": transmissions.get("travel"),
-            "unknown": transmissions.get("unknown")
+            "travel": transmissions.get("travel", 0),
+            "unknown": transmissions.get("unknown", 0)
         }
 
         # check that we have all the math right

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -227,7 +227,14 @@ def get_table_tags(soup: BeautifulSoup) -> List[element.Tag]:
     """
     Takes in a BeautifulSoup object and returns an array of the tables we need
     """
-    headers = ['Cases by Date', 'Test Results', 'Cases by Source', 'Cases by Age Group', 'Cases by Gender', 'Cases by Race']
+    headers = [
+        'Cases by Date',
+        'Test Results',
+        'Proportion of Cases Attributable to Specific Exposure Locations',
+        'Cases by Age Group',
+        'Cases by Gender',
+        'Cases by Race'
+    ]
     return [get_table(header, soup) for header in headers]
 
 def get_county() -> Dict:

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -174,8 +174,6 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, how:
             [transmissions.get(category, 0) for category in transmissions.keys()
              if category in community_categories]
         )
-        if not community:
-            community = -1
 
         coerced_transmissions = {}
         coerced_transmissions["from_contact"] = from_contact

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -117,13 +117,33 @@ def transform_cases(cases_tag: element.Tag) -> Dict[str, TimeSeries]:
 
     return { 'cases': cases, 'deaths': deaths }
 
-def transform_transmission(transmission_tag: element.Tag, total_cases: int, normalize: bool = True) -> Dict[str, int]:
+def transform_transmission(
+        transmission_tag: element.Tag,
+        total_cases: int,
+        standardize: bool = True
+) -> Dict[str, int]:
     """
     Takes in a BeautifulSoup tag for the transmissions table and breaks it into
     a dictionary. Fields are either the original from data source or are normalized
-    into groups consistent with other datasets, by using `normalize=True` (default).
-    Data model:
-      {'community': -1, 'from_contact': -1, 'travel': -1, 'unknown': -1}
+    into groups consistent with other datasets, by using `standardize=True` (default).
+
+    Parameters
+    ----------
+    transmission_tag : element.Tag
+        A BeautifulSoup table tag containing transmission source data
+
+    total_cases: int
+        The total number of COVID-19 cases reported by the county
+
+    standardize: bool
+        Flag to standardize the data into BAPD-consistent fields
+
+    Returns
+    -------
+    transmissions : dict
+        A dictionary keyed by transmission source, with calculated 
+        number of cases as the values. By default the fields are:
+        {'community': -1, 'from_contact': -1, 'travel': -1, 'unknown': -1}
     """
     transmissions = {}
     rows = parse_table(transmission_tag)
@@ -152,8 +172,8 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int, norm
         type = transmission_type_conversion[type]
         transmissions[type] = case_count
 
-    if normalize:
-        # normalize categories into groups consistent with other datasets
+    if standardize:
+        # standardize categories into groups consistent with other datasets
         # those groups are "from_contact", "travel", "unknown" and "community"
 
         from_contact_categories = [
@@ -321,7 +341,7 @@ def get_county() -> Dict:
         'series': transform_cases(hist_cases),
         'case_totals': {
             'transmission_cat': transform_transmission(cases_by_source, total_cases),
-            'transmission_cat_orig': transform_transmission(cases_by_source, total_cases, normalize=False),
+            'transmission_cat_orig': transform_transmission(cases_by_source, total_cases, standardize=False),
             'age_group': transform_age(cases_by_age),
             'race_eth': transform_race_eth(cases_by_race),
             'gender': transform_gender(cases_by_gender)

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -117,7 +117,7 @@ def transform_cases(cases_tag: element.Tag) -> Dict[str, TimeSeries]:
 
     return { 'cases': cases, 'deaths': deaths }
 
-def transform_transmission(transmission_tag: element.Tag) -> Dict[str, int]:
+def transform_transmission(transmission_tag: element.Tag) -> Dict[str, float]:
     """
     Takes in a BeautifulSoup tag for the transmissions table and breaks it into
     a dictionary of type:

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -141,9 +141,9 @@ def transform_transmission(transmission_tag: element.Tag, total_cases: int) -> D
         'congregate care': 'congregate_care',
         'health care': 'health_care',
         'household': 'household',
-        'large gathering': 'gathering_small',
+        'large gathering': 'gathering_large',
         'other': 'other',
-        'small gathering': 'gathering_large',
+        'small gathering': 'gathering_small',
         'travel': 'travel',
         'unknown': 'unknown',
         'workplace': 'workplace'

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -182,30 +182,25 @@ def transform_transmission(
             "workplace",
             "gathering_small"
         ]
-        from_contact = sum(
-            [transmissions.get(category, 0) for category in transmissions.keys()
-             if category in from_contact_categories]
-        )
 
         community_categories = [
             "health_care",
             "gathering_large",
             "other"
         ]
-        community = sum(
-            [transmissions.get(category, 0) for category in transmissions.keys()
-             if category in community_categories]
-        )
 
-        normalized_transmissions = {}
-        normalized_transmissions["from_contact"] = from_contact
-        normalized_transmissions["community"] = community
-        normalized_transmissions["travel"] = transmissions.get("travel", -1)
-        normalized_transmissions["unknown"] = transmissions.get("unknown", -1)
+        standardized_transmissions = {
+            "from_contact": sum(transmissions[category]
+                                for category in from_contact_categories),
+            "community": sum(transmissions[category]
+                             for category in community_categories),
+            "travel": transmissions.get("travel"),
+            "unknown": transmissions.get("unknown")
+        }
 
         # check that we have all the math right
-        assert sum(normalized_transmissions.values()) == sum(transmissions.values())
-        transmissions = normalized_transmissions
+        assert sum(standardized_transmissions.values()) == sum(transmissions.values())
+        transmissions = standardized_transmissions
 
     else:
         pass

--- a/tests/data/test_valid_output.py
+++ b/tests/data/test_valid_output.py
@@ -68,7 +68,7 @@ def test_scraper_output_format_is_valid(county: str) -> None:
         }),
         Optional('transmission_cat'): Exact({
             # The keys here are not standardized.
-            str: int
+            str: float
         })
     })
 

--- a/tests/data/test_valid_output.py
+++ b/tests/data/test_valid_output.py
@@ -68,7 +68,7 @@ def test_scraper_output_format_is_valid(county: str) -> None:
         }),
         Optional('transmission_cat'): Exact({
             # The keys here are not standardized.
-            str: float
+            str: int
         })
     })
 


### PR DESCRIPTION
This is a hotfix to handle the changes to Sonoma County's "Coronavirus Cases" page, and specifically to its "Cases by Source" table. It appears that table has been replaced by a table called "Proportion of Cases Attributable to Specific Exposure Locations," and that instead of raw case counts, several percentage figures are given for active cases, cases within a given time frame ("30-44 Days Ago"), and all time. The descriptions of the transmission settings (e.g. "Workplace") have also changed and become more granular.

In this batch of changes, I'm erring on the side of capturing the new granularity rather than on consistency with our prior categories, since the more granular data may be more helpful/informational. I've also made the call to only grab the percentage figure for "All Time" for each, which I think follows since we're storing this data under the key `case_totals`. There's an argument to be made for actually _running_ the calculation of the percentage against the case totals, and surfacing that. Or not. Would welcome any feedback!