### PR TITLE
Add Napa County data scraper

### DIFF
--- a/covid19_sfbayarea/data/__init__.py
+++ b/covid19_sfbayarea/data/__init__.py
@@ -2,6 +2,7 @@ from typing import Dict, Any
 from . import alameda
 from . import san_francisco
 from . import marin
+from . import napa
 from . import sonoma
 from . import solano
 from . import san_mateo
@@ -11,7 +12,7 @@ scrapers: Dict[str, Any] = {
     'alameda': alameda,
     # 'contra_costa': None,
     'marin': marin,
-    # 'napa': None,
+    'napa': napa,
     'san_francisco': san_francisco,
     'san_mateo': san_mateo,
     'santa_clara': santa_clara,

--- a/covid19_sfbayarea/data/arcgis.py
+++ b/covid19_sfbayarea/data/arcgis.py
@@ -1,0 +1,105 @@
+import requests
+from typing import Any, Dict, Generator
+from urllib.parse import urljoin
+from .errors import BadRequest
+
+
+class ArcGisFeatureServer:
+    """
+    A thin wrapper around ArcGIS's FeatureServer API. The capabilities are
+    pretty limited, but it gives us a useful wrapper for the data-focused parts
+    of the API that we need.
+
+    Parameters
+    ----------
+    base_url : str
+        The base URL of the server, including the "Unique Service ID". Example:
+        ``'https://services1.arcgis.com/Ko5rxt00spOfjMqj'``
+    """
+    def __init__(self, base_url: str):
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.base_url = base_url
+        self.service_base_url = urljoin(base_url, 'ArcGIS/rest/services/')
+
+    def _build_query_url(self, service: str, table_id: int) -> str:
+        query_path = f'{service}/FeatureServer/{table_id}/query'
+        return urljoin(self.service_base_url, query_path)
+
+    def query(
+        self,
+        service: str,
+        table_id: int = 0,
+        *,  # Parameters below must be specified as keywords. -----------------
+        where: str = '1=1',
+        outFields: str = None,
+        groupByFieldsForStatistics: str = None,
+        orderByFields: str = None,
+        **params: Any
+     ) -> Generator[Dict, None, None]:
+        """
+        Query a table/layer from an ArcGIS Feature Service. This will yield
+        the ``attributes`` field of each result record.
+
+        ArcGIS queries normally require a ``where`` clause, but this method
+        provides a default ``where`` that selects all rows to simplify some
+        queries.
+
+        The parameters of this method don't follow typical python convention
+        because they correspond directly to ArcGIS ``query`` API parameters.
+        Only a subset of commonly used parameters are explicitly listed here
+        for code completion support. For a full reference, see:
+            https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm
+
+        Parameters
+        ----------
+        service : str
+            The name of the service to query, e.g. ``'CaseDataDemographics'``.
+        table_id : int
+            The table/layer ID to query from the service. These IDs are usually
+            sequential and start from 0.
+        where : str
+        outFields : str
+        groupByFieldsForStatistics : str
+        orderByFields : str
+        **params
+            Additional query parameters accepted by the ArcGIS API. Reference:
+            - https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm
+            - https://developers.arcgis.com/documentation/mapping-apis-and-location-services/data-hosting/services/feature-service/
+
+        Yields
+        ------
+        dict
+            This yields the ``attributes`` field of each resulting feature.
+            (Features are GeoJSON, but since we don't care about the geometry,
+            we skip over it and just yield the data.)
+        """
+        url = self._build_query_url(service, table_id)
+        next_params = params.copy()
+        next_params.update({
+            'f': 'json',
+            'returnGeometry': False,
+            'where': where,
+            'outFields': outFields,
+            'groupByFieldsForStatistics': groupByFieldsForStatistics,
+            'orderByFields': orderByFields
+        })
+
+        while True:
+            response = requests.get(url, params=next_params)
+            data = response.json()
+            if 'error' in data:
+                message = data['error']['message']
+                if 'details' in data['error']:
+                    details = ' '.join(data['error']['details'])
+                    message = f'{message} ({details})'
+                raise BadRequest(message, response=response)
+
+            for feature in data['features']:
+                yield feature['attributes']
+
+            if not data.get('exceededTransferLimit', False):
+                return
+
+            offset = next_params.get('resultOffset', 0) + len(data['features'])
+            next_params['resultOffset'] = offset

--- a/covid19_sfbayarea/data/napa.py
+++ b/covid19_sfbayarea/data/napa.py
@@ -1,0 +1,321 @@
+from collections import defaultdict
+from datetime import date, datetime
+import re
+import requests
+from typing import Dict, List, Iterable
+from ..errors import FormatError
+from ..utils import assert_equal_sets, PACIFIC_TIME
+from .arcgis import ArcGisFeatureServer
+
+
+# Most data comes from this ArcGIS server.
+ARCGIS_SERVER_URL = 'https://services1.arcgis.com/Ko5rxt00spOfjMqj'
+# The 'CaseDataDemographics' service is used for most of our data; it lists
+# *every case* the county knows about!
+CASES_SERVICE = 'CaseDataDemographics'
+# Tests data comes from a Google Sheet proxies through livestories.com.
+TESTS_SPREADSHEET_URL = 'https://legacy.livestories.com/dataset.json?dashId=6014a050c648870017b6dc84'
+
+
+def get_county() -> Dict:
+    """
+    Get data for Santa Napa County.
+    """
+    notes = ('Cases are dated by the time a test specimen was collected (i.e. '
+             'the earliest known time of a case\'s infection). In some cases, '
+             'the specimen collection date is unknown, and the test result '
+             'time is used instead. '
+             'Napa also provides a narrow range of race/ethnicity groups than '
+             'most other counties. Many groups (e.g. african-american, asian, '
+             'pacific islander) are collected under "other". '
+             'Additionally, Napa County does not provide information about '
+             'comorbidities/underlying conditions or methods of transmission. '
+             'Test data is only provided on a weekly basis; we attribute '
+             'tests to the last day of the week in which the test was taken. '
+             'Test data is updated on Tuesdays, but a test week is '
+             'Sunday-Saturday.')
+
+    api = ArcGisFeatureServer(ARCGIS_SERVER_URL)
+
+    return {
+        'name': 'Napa',
+        'update_time': get_latest_update(api).isoformat(),
+        # The dashboard loads data from ArcGIS and from several Google Sheets
+        # proxied through livestories.com (see URLs in constants above).
+        'source_url': 'https://legacy.livestories.com/s/v2/coronavirus-report-for-napa-county-ca/9065d62d-f5a6-445f-b2a9-b7cf30b846dd/',
+        'meta_from_source': '',
+        'meta_from_baypd': notes,
+        'series': {
+            'cases': get_timeseries_cases(api),
+            'deaths': get_timeseries_deaths(api),
+            'tests': get_timeseries_tests(),
+        },
+        'case_totals': get_case_totals(api),
+        'death_totals': get_death_totals(api),
+        # Napa does not currently provide demographic breakdowns for testing,
+        # so no test totals right now.
+    }
+
+
+def get_latest_update(api: ArcGisFeatureServer) -> datetime:
+    data = api.query(CASES_SERVICE,
+                     outFields='MAX(EditDate_1) as edit_date')
+    result = next(data)
+    return datetime.fromtimestamp(result['edit_date'] / 1000, tz=PACIFIC_TIME)
+
+
+def get_timeseries_cases(api: ArcGisFeatureServer) -> List:
+    """
+    Get a timeseries of cases.
+
+    Some cases in Napa's data have a test result date, but not a test specimen
+    collection date. Napa's dashboard works around this by showing cases by
+    test result date.
+
+    However, we and Wikimedia Commons take a different approach: We list cases
+    by specimen collection date. If it's not available, we fall back to the
+    test result date as the next most accurate thing.
+    """
+    dated = {
+        row['DtLabCollect']: row['count']
+        for row in api.query(CASES_SERVICE,
+                             where='DtLabCollect <> NULL',
+                             outFields='DtLabCollect,COUNT(*) AS count',
+                             groupByFieldsForStatistics='DtLabCollect',
+                             orderByFields='DtLabCollect asc')
+    }
+
+    undated = {
+        row['DtLabResult']: row['count']
+        for row in api.query(CASES_SERVICE,
+                             where='DtLabCollect IS NULL',
+                             outFields='DtLabResult,COUNT(*) AS count',
+                             groupByFieldsForStatistics='DtLabResult',
+                             orderByFields='DtLabResult asc')
+    }
+
+    dates = sorted(set(list(dated.keys()) + list(undated.keys())))
+
+    # Cumulative counts are provided by the county, but because of how we are
+    # mixing date regimes, we need to calculate our own.
+    total = 0
+    timeseries  = []
+    for case_date in dates:
+        count = dated.get(case_date, 0) + undated.get(case_date, 0)
+        total += count
+        timeseries.append({
+            'date': date.fromtimestamp(case_date / 1000).isoformat(),
+            'cases': count,
+            'cumul_cases': total,
+        })
+
+    return timeseries
+
+
+def get_timeseries_deaths(api: ArcGisFeatureServer) -> List:
+    """
+    Get a timeseries of deaths.
+    """
+    # First build a lookup table for records with no collection date.
+    data = api.query(CASES_SERVICE,
+                     where='DtDeath <> NULL',
+                     outFields='DtDeath,COUNT(*) AS deaths',
+                     groupByFieldsForStatistics='DtDeath',
+                     orderByFields='DtDeath asc')
+    total = 0
+    deaths = []
+    for entry in data:
+        total += entry['deaths']
+        deaths.append({
+            'date': date.fromtimestamp(entry['DtDeath'] / 1000).isoformat(),
+            'deaths': entry['deaths'],
+            'cumul_deaths': total
+        })
+
+    return deaths
+
+
+def get_timeseries_tests() -> List:
+    # Testing data comes from a Google Sheet proxies through livestories.com,
+    # rather than ArcGIS.
+    data = requests.get(TESTS_SPREADSHEET_URL).json()
+
+    # Validate that the series are what we expect.
+    if 'number of tests' not in data['series'][0]['name'].lower():
+        raise FormatError('Tests data series 0 should have been # of tests, '
+                          f'but got: "{data["series"][0]["name"]}"')
+    if 'positivity rate' not in data['series'][1]['name'].lower():
+        raise FormatError('Tests data series 1 should have been positivity, '
+                          f'but got: "{data["series"][1]["name"]}"')
+
+    # X values are formatted like "2020 11/8 - 11/14"
+    x_pattern = re.compile(r'''
+        ^
+        (\d+)                          # Year
+        \s+
+        (\d+)/(\d+)                    # Month/Day for start of week
+        \s*[\-\u00a0\u2010-\u2015]\s*  # Dash (of various sorts) optionally surrounded by spaces
+        (\d+)/(\d+)                    # Month/Day for end of week
+    ''', re.IGNORECASE | re.VERBOSE)
+    x_values = data['categories']
+    test_counts = data['series'][0]['data']
+    test_positives = data['series'][1]['data']
+
+    total = 0
+    total_positive = 0
+    timeseries = []
+    for index, week in enumerate(x_values):
+        x_data = x_pattern.match(week)
+        if not x_data:
+            raise FormatError(f'Could not parse week {index} name: "{week}"')
+
+        result_date = date(int(x_data.group(1)),
+                           int(x_data.group(4)),
+                           int(x_data.group(5)))
+        count = test_counts[index]['y']
+        total += count
+        rate = test_positives[index]['y']
+        positive_count = round(count * rate / 100)
+        total_positive += positive_count
+        timeseries.append({
+            'date': result_date.isoformat(),
+            'tests': count,
+            'positive': positive_count,
+            'cumul_tests': total,
+            'cumul_pos': total_positive,
+            # This field isn't really standard, but it's here because it's the
+            # "true" value, while `positive` is a rounded calculation.
+            'positivity': rate,
+        })
+
+    return timeseries
+
+
+def format_gender_results(data: Iterable[Dict]) -> Dict[str, int]:
+    """
+    Format the output of an API call for counts of rows by gender.
+    """
+    # We can't use a comprehension here because values are not completely
+    # standardized across rows (e.g. both "unknown" and None == "unknown").
+    result: Dict[str, int] = defaultdict(int)
+    for row in data:
+        key = (row['Sex'] or 'unknown').strip().lower()
+        result[key] += row['count']
+    try:
+        assert 'male' in result
+        assert 'female' in result
+    except AssertionError:
+        raise FormatError('Missing explicity male/female gender categories, '
+                          f'got: {list(result.keys())}')
+    return result
+
+
+def format_race_results(data: Iterable[Dict]) -> Dict[str, int]:
+    """
+    Format the output of an API call for counts of rows by gender.
+    """
+    # Napa groups several other race/ethnicity groups we normally break out
+    # into "other".
+    mapping = {
+        'hispanic': 'Latinx_or_Hispanic',
+        'non-hispanic white': 'White',
+        'other': 'Other',
+        'unknown': 'Unknown'
+    }
+
+    # We can't use a comprehension here because values are not completely
+    # standardized across rows (e.g. both "unknown" and None == "unknown").
+    result: Dict[str, int] = defaultdict(int)
+    for row in data:
+        key = (row['RaceEthn'] or 'unknown').strip().lower()
+        result[key] += row['count']
+
+    # Validate expected keys and remap them to our keys.
+    assert_equal_sets(mapping.keys(), result.keys())
+    return {mapping[key]: value
+            for key, value in result.items()}
+
+
+def format_age_results(data: Iterable[Dict]) -> List[Dict]:
+    # NOTE: values aren't totally standardized, so we can't use a comprehension
+    # here (we need need to add the results of some rows together).
+    groups: Dict[str, int] = defaultdict(int)
+    for row in data:
+        key = (row['AgeGroup'] or 'unknown').strip()
+        # Remove leading zeroes from ages, e.g. "05-09"
+        ages = [age.strip().lstrip('0') or '0'
+                for age in key.split('-')]
+        key = '-'.join(ages)
+        groups[key] += row['count']
+
+    # Sort groups by the int value of the first age (e.g. by `5` in `"5-9"`).
+    def sortable_group(group: Dict) -> int:
+        return int(group['group'].split('-')[0].strip('+'))
+
+    results = [{'group': key, 'raw_count': value}
+               for key, value in groups.items()]
+    return sorted(results, key=sortable_group)
+
+
+def get_case_totals(api: ArcGisFeatureServer) -> Dict:
+    return {
+        'gender': get_cases_by_gender(api),
+        'age_group': get_cases_by_age(api),
+        'race_eth': get_cases_by_race(api),
+        # NOTE: Napa does not appear to have any source of information about
+        # comorbidities/underlying conditions or type of transmission, so no
+        # `underlying_cond` or `transmission_cat` fields.
+    }
+
+
+def get_cases_by_gender(api: ArcGisFeatureServer) -> Dict[str, int]:
+    data = api.query(CASES_SERVICE,
+                     outFields='Sex,COUNT(*) AS count',
+                     groupByFieldsForStatistics='Sex')
+    return format_gender_results(data)
+
+
+def get_cases_by_age(api: ArcGisFeatureServer) -> List[Dict]:
+    data = api.query(CASES_SERVICE,
+                     outFields='AgeGroup,COUNT(*) AS count',
+                     groupByFieldsForStatistics='AgeGroup')
+    return format_age_results(data)
+
+
+def get_cases_by_race(api: ArcGisFeatureServer) -> Dict:
+    data = api.query(CASES_SERVICE,
+                     outFields='RaceEthn,COUNT(*) AS count',
+                     groupByFieldsForStatistics='RaceEthn')
+    return format_race_results(data)
+
+
+def get_death_totals(api: ArcGisFeatureServer) -> Dict:
+    return {
+        'gender': get_deaths_by_gender(api),
+        'age_group': get_deaths_by_age(api),
+        'race_eth': get_deaths_by_race(api),
+        # NOTE: Napa does not appear to have any source of information about
+        # comorbidities/underlying conditions or type of transmission, so no
+        # `underlying_cond` or `transmission_cat` fields.
+    }
+
+
+def get_deaths_by_gender(api: ArcGisFeatureServer) -> Dict[str, int]:
+    data = api.query(CASES_SERVICE,
+                     outFields='Sex,COUNT(DtDeath) AS count',
+                     groupByFieldsForStatistics='Sex')
+    return format_gender_results(data)
+
+
+def get_deaths_by_age(api: ArcGisFeatureServer) -> List[Dict]:
+    data = api.query(CASES_SERVICE,
+                     outFields='AgeGroup,COUNT(DtDeath) AS count',
+                     groupByFieldsForStatistics='AgeGroup')
+    return format_age_results(data)
+
+
+def get_deaths_by_race(api: ArcGisFeatureServer) -> Dict[str, int]:
+    data = api.query(CASES_SERVICE,
+                     outFields='RaceEthn,COUNT(DtDeath) AS count',
+                     groupByFieldsForStatistics='RaceEthn')
+    return format_race_results(data)

--- a/covid19_sfbayarea/data/napa.py
+++ b/covid19_sfbayarea/data/napa.py
@@ -258,64 +258,37 @@ def format_age_results(data: Iterable[Dict]) -> List[Dict]:
 
 
 def get_case_totals(api: ArcGisFeatureServer) -> Dict:
-    return {
-        'gender': get_cases_by_gender(api),
-        'age_group': get_cases_by_age(api),
-        'race_eth': get_cases_by_race(api),
-        # NOTE: Napa does not appear to have any source of information about
-        # comorbidities/underlying conditions or type of transmission, so no
-        # `underlying_cond` or `transmission_cat` fields.
-    }
-
-
-def get_cases_by_gender(api: ArcGisFeatureServer) -> Dict[str, int]:
-    data = api.query(CASES_SERVICE,
-                     outFields='Sex,COUNT(*) AS count',
-                     groupByFieldsForStatistics='Sex')
-    return format_gender_results(data)
-
-
-def get_cases_by_age(api: ArcGisFeatureServer) -> List[Dict]:
-    data = api.query(CASES_SERVICE,
-                     outFields='AgeGroup,COUNT(*) AS count',
-                     groupByFieldsForStatistics='AgeGroup')
-    return format_age_results(data)
-
-
-def get_cases_by_race(api: ArcGisFeatureServer) -> Dict:
-    data = api.query(CASES_SERVICE,
-                     outFields='RaceEthn,COUNT(*) AS count',
-                     groupByFieldsForStatistics='RaceEthn')
-    return format_race_results(data)
+    return get_totals(api, count_by='*')
 
 
 def get_death_totals(api: ArcGisFeatureServer) -> Dict:
+    return get_totals(api, count_by='DtDeath')
+
+
+def get_totals(api: ArcGisFeatureServer, count_by: str) -> Dict:
     return {
-        'gender': get_deaths_by_gender(api),
-        'age_group': get_deaths_by_age(api),
-        'race_eth': get_deaths_by_race(api),
+        'gender': format_gender_results(
+            api.query(
+                CASES_SERVICE,
+                outFields=f'Sex,COUNT({count_by}) AS count',
+                groupByFieldsForStatistics='Sex'
+            )
+        ),
+        'age_group': format_age_results(
+            api.query(
+                CASES_SERVICE,
+                outFields=f'AgeGroup,COUNT({count_by}) AS count',
+                groupByFieldsForStatistics='AgeGroup'
+            )
+        ),
+        'race_eth': format_race_results(
+            api.query(
+                CASES_SERVICE,
+                outFields=f'RaceEthn,COUNT({count_by}) AS count',
+                groupByFieldsForStatistics='RaceEthn'
+            )
+        ),
         # NOTE: Napa does not appear to have any source of information about
         # comorbidities/underlying conditions or type of transmission, so no
         # `underlying_cond` or `transmission_cat` fields.
     }
-
-
-def get_deaths_by_gender(api: ArcGisFeatureServer) -> Dict[str, int]:
-    data = api.query(CASES_SERVICE,
-                     outFields='Sex,COUNT(DtDeath) AS count',
-                     groupByFieldsForStatistics='Sex')
-    return format_gender_results(data)
-
-
-def get_deaths_by_age(api: ArcGisFeatureServer) -> List[Dict]:
-    data = api.query(CASES_SERVICE,
-                     outFields='AgeGroup,COUNT(DtDeath) AS count',
-                     groupByFieldsForStatistics='AgeGroup')
-    return format_age_results(data)
-
-
-def get_deaths_by_race(api: ArcGisFeatureServer) -> Dict[str, int]:
-    data = api.query(CASES_SERVICE,
-                     outFields='RaceEthn,COUNT(DtDeath) AS count',
-                     groupByFieldsForStatistics='RaceEthn')
-    return format_race_results(data)


### PR DESCRIPTION
This adds data support for Napa County (wow, that was a long time coming). It's mostly based on the ArcGIS feature server identified by @1ec5, which lists *every case* in Napa County.

There are a few questionable bits I’d love feedback on here:

1. All cases have a date for when the test results were received, but a few do not have a date for when the test was *taken*. The county works around this by showing cases by test result received date, while @1ec5 worked around it for Wikimedia Commons by doing the same thing I’m doing here: using the test taken date where available, and the test received date otherwise. I think this makes the most sense, but it will make our numbers differ slightly from the county dashboard’s display.
    - See the Wikimedia Commons data at: https://commons.wikimedia.org/wiki/COVID-19_pandemic_in_the_San_Francisco_Bay_Area#Napa_County
    - And the code: https://github.com/1ec5/external-data-bot/blob/master/scripts/covid19/US/CA/napa-county.sh

2. Napa only publishes test information on a weekly basis. I’ve put that into our standard format by attributing the week’s test to the final day of the week (Saturdays).

3. Similarly, Napa publishes test positivity *rates*, not counts. To make this comparable with other counties, I’ve done the calculation to get counts, and included the rate as a `rate` property on each timeseries entry.

Fixes #24.