### PR TITLE
Add data scraper for Contra Costa County

### DIFF
--- a/covid19_sfbayarea/data/__init__.py
+++ b/covid19_sfbayarea/data/__init__.py
@@ -1,16 +1,17 @@
 from typing import Dict, Any
 from . import alameda
-from . import san_francisco
+from . import contra_costa
 from . import marin
 from . import napa
-from . import sonoma
-from . import solano
+from . import san_francisco
 from . import san_mateo
 from . import santa_clara
+from . import solano
+from . import sonoma
 
 scrapers: Dict[str, Any] = {
     'alameda': alameda,
-    # 'contra_costa': None,
+    'contra_costa': contra_costa,
     'marin': marin,
     'napa': napa,
     'san_francisco': san_francisco,

--- a/covid19_sfbayarea/data/contra_costa.py
+++ b/covid19_sfbayarea/data/contra_costa.py
@@ -1,0 +1,414 @@
+"""
+Contra Costa County
+
+Contra Costa builds its dashboard with Qlik. Qlik can be a bit complicated, so
+we've also got an API client called ``qlik.QlikClient``.
+
+There's not an obvious way to pull directly from whatever raw data the Qlik
+charts are based on, so instead we have to pull the data that backs each chart.
+(For example, if you dig around enough, it appears there is a single table with
+all timeseries, but there's no clear way to get the data from the table.
+Instead, we get the data behind each of the cases by date chart, deaths by date
+chart, and so on.)
+
+How do we determine the chart IDs to pull data from? When browsing one of the
+dashboard pages, you'll a JS file loaded that is named for the dashboard.
+For example, on the https://www.coronavirus.cchealth.org/overview dashboard, a
+JS file named dashboard.cchealth.org/extensions/COVIDDashboard/Overview.js.
+That JS file will have a series of calls to
+``getObject('<dom_id>', '<chart_id>', ...)`` like so:
+
+    overviewApp.getObject('QV01','gumQeX',{noSelections: true, noInteraction: false});
+    overviewApp.getObject('QV02','LuVGBZ',{noSelections: true, noInteraction: false});
+    overviewApp.getObject('QV03','jWjFxe',{noSelections: true, noInteraction: false});
+    overviewApp.getObject('QV04','cWjnGdK',{noSelections: true, noInteraction: false});
+    overviewApp.getObject('QV05','bZFxmu',{noSelections: true, noInteraction: false});
+
+For each line, the first string is the ID of a DOM element on the page that
+contains the chart and the second string is the chart ID in Qlik.
+
+To get the Qlik chart ID for any chart on the page, use your browser's web
+inspector to find the ``<div>`` that holds the chart and get its ID. Example:
+
+    <div class="chart qvobject" id="QV05">...</div>
+
+Then look in the JS file for the line like above that maps that DOM ID to a
+Qlik chart ID. In the example above, the DOM ID was ``'QV05'``, and you can see
+in the example JS that the matching Qlik chart ID would be ``'bZFxmu'``.
+
+Dashboards:
+Overview - https://www.coronavirus.cchealth.org/overview
+           https://dashboard.cchealth.org/extensions/COVIDDashboard/Overview.html
+           ID: b7d7f869-fb91-4950-9262-0b89473ceed6
+
+Vavvines - https://www.coronavirus.cchealth.org/vaccine
+           ID: 8dea25ae-3782-48ef-9199-508a3163297e
+"""
+
+from collections import defaultdict
+from datetime import date, datetime
+from typing import Dict, List
+from ..errors import FormatError
+from ..utils import assert_equal_sets, parse_datetime
+from .qlik import QlikClient
+
+
+CHART_IDS = {
+    # Timeseries
+    'new_cases': 'cWjnGdK',
+    'total_cases': 'jWjFxe',
+    'deaths': 'zKvfuW',
+    'total_tests': 'ejpTS',
+    'test_positivity': 'VapZPL',
+
+    # Case demographics
+    'cases_by_gender': 'tAqmEW',
+    'cases_by_age': 'mmXYJhJ',
+    'cases_by_race': 'ppmdr',
+    'cases_by_ethnicity': 'PEqthPy',
+
+    # Death demographics
+    'deaths_by_gender': 'KHwxYe',
+    'deaths_by_age': 'pWrYQeL',
+    'deaths_by_race': 'LjJk',
+    'deaths_by_ethnicity': 'ffcHDa',
+
+    # Contra Costa does not publish demographic breakdowns for testing.
+}
+
+
+def get_county() -> Dict:
+    """
+    Get data for Contra Costa County.
+    """
+    api = QlikClient('wss://dashboard.cchealth.org/app/',
+                     'b7d7f869-fb91-4950-9262-0b89473ceed6')
+    notes = ('Positive test counts are not published by the county, so they '
+             'are estimated from daily positivity rates. Positivity rates are '
+             'are not published for dates as early as some tests are, so '
+             'positive test counts before 2020-03-18 may incorrectly show 0. '
+             'Unlike other counties, Contra Costa separates hispanic '
+             'ethnicity from racial demographics, so "latinx" is not included '
+             'in `case_totals.race_eth` or `death_totals.race_eth`. Latinx '
+             'vs. non-latinx is shown in separate `case_totals.ethnicity` and '
+             '`death_total.ethnicity` groupings. '
+             'Contra Costa also does not tally native american or pacific '
+             'islander as races, and they are instead included as "other".'
+             'Demographic information is not available for tests.')
+
+    with api:
+        # Set language to English (so we only get one language's entries, e.g.
+        # we only get "Female" instead of "Female" + "Femenino").
+        api.select_field_value('LabelLanguage', 'English')
+
+        return {
+            'name': 'Contra Costa',
+            'update_time': get_latest_update(api).isoformat(),
+            'source_url': 'https://www.coronavirus.cchealth.org/overview',
+            'meta_from_source': '',
+            'meta_from_baypd': notes,
+            'series': {
+                'cases': get_timeseries_cases(api),
+                'deaths': get_timeseries_deaths(api),
+                'tests': get_timeseries_tests(api),
+            },
+            'case_totals': get_case_totals(api),
+            'death_totals': get_death_totals(api),
+        }
+
+
+def get_latest_update(api: QlikClient) -> datetime:
+    return parse_datetime(api.get_app_layout()['qLayout']['qLastReloadTime'])
+
+
+def get_chart_data(api: QlikClient, chart_id: str) -> List[List[Dict]]:
+    """
+    Get the underlying data for a standard chart by its Qlik object ID. This
+    does *not* work for "stacked" charts, with multiple overlaid series.
+    """
+    chart = api.get_data(chart_id)
+    return chart['qLayout']['qHyperCube']['qDataPages'][0]['qMatrix']
+
+
+def get_timeseries_cases(api: QlikClient) -> List[dict]:
+    new_cases_data = get_chart_data(api, CHART_IDS['new_cases'])
+    total_cases_data = get_chart_data(api, CHART_IDS['total_cases'])
+
+    cases = {api.parse_date(x['qNum']): {'date': api.parse_date(x['qNum']).isoformat(),
+                                         'cases': y['qNum']}
+             for x, y in new_cases_data}
+    for x, y in total_cases_data:
+        day = api.parse_date(x['qNum'])
+        record = cases.get(day)
+        if not record:
+            record = {'date': day.isoformat()}
+            cases[day] = record
+
+        record['cumul_cases'] = y['qNum']
+
+    result = [cases[day] for day in sorted(cases.keys())]
+
+    # Sanity-check daily cases vs. totals
+    total = 0
+    for index, record in enumerate(result):
+        total += record['cases']
+        if record['cumul_cases'] != total:
+            raise FormatError(f'Sum of daily cases != cumul_cases at record {index} (date: {record["day"]})')
+
+    return result
+
+
+def get_timeseries_deaths(api: QlikClient) -> List[dict]:
+    data = get_chart_data(api, CHART_IDS['deaths'])
+
+    total = 0
+    results = []
+    # LTCF = Long Term Care Facility (e.g. nursing homes)
+    # LTCF deaths include both residents and staff.
+    for x, non_ltcf, ltcf in data:
+        day = api.parse_date(x['qNum'])
+        deaths = non_ltcf['qNum'] + ltcf['qNum']
+        total += deaths
+        results.append({
+            'date': day.isoformat(),
+            'deaths': deaths,
+            'cumul_deaths': total,
+            'ltcf_deaths': ltcf['qNum'],
+            'non_ltcf_deaths': non_ltcf['qNum'],
+        })
+
+    return results
+
+
+def get_timeseries_tests(api: QlikClient) -> List[dict]:
+    """
+    Calculate a timeseries of tests.
+
+    The dashboard has daily tests and daily total tests as separate charts, but
+    they don't quite agree. We use the daily total tests chart and calculate
+    daily tests by taking the difference between each day.
+
+    More detail: daily total tests starts earlier (but clearly not on the first
+    day there were tests, given the values). Daily tests starts later *and* has
+    ``0`` as the value for the first several days, despite the daily totals
+    having > 0 differences on those days. Once daily tests starts having values
+    it lines up with the differences between daily total tests entries, so it
+    seems like daily total tests is a more complete and accurate chart.
+    """
+    tests: Dict[date, Dict] = defaultdict(lambda: {
+        'tests': -1,
+        'positive': -1,
+        'negative': -1,
+        'pending': -1,
+        'cumul_tests': -1,
+        'cumul_pos': -1,
+        'cumul_neg': -1,
+        'cumul_pend': -1,
+        'positivity': -1
+    })
+
+    total_tests_data = get_chart_data(api, CHART_IDS['total_tests'])
+    for x, y in total_tests_data:
+        day = api.parse_date(x['qNum'])
+        tests[day]['cumul_tests'] = y['qNum']
+
+    # There's no chart with total positive tests, so we use the *rate* to
+    # calculate it. Note also that this is a rolling average, not the actual
+    # rate on the day, so this is not the most accurate. :(
+    #
+    # This chart is a "stacked" chart (it has two series -- rate and equity
+    # metric rate), so is structured in a more complex way.
+    # The data is a list of dates, where each has a `qSubNodes` list with one
+    # item from each series. Those items each have their own `qSubNodes` list
+    # with one item that contains the actual value.
+    positive_rate_chart = api.get_data(CHART_IDS['test_positivity'])
+    positive_rate_data = positive_rate_chart['qLayout']['qHyperCube']['qStackedDataPages'][0]['qData'][0]['qSubNodes']
+    for node in positive_rate_data:
+        day = api.parse_date(node['qValue'])
+        # In the first list of subnodes:
+        #   0 = "% Positive Equity Metric"
+        #   1 = "% Tested Positive 7-Day Average"
+        # In the nested list of subnodes, there's only one item, which has the
+        # actual value.
+        rate = node['qSubNodes'][1]['qSubNodes'][0]['qValue']
+        # Store the rate; we need to do anothe pass to calculate daily tests
+        # before we can use the rate to calculate daily positives.
+        tests[day]['positivity'] = rate
+
+    # Clean up, sanity-check, and put the results in order.
+    result = []
+    total = 0
+    total_positive = 0
+    found_first = False
+    for day in sorted(tests.keys()):
+        record = tests[day]
+        # Skip over all items earlier than the first day with total tests.
+        # (It might be possible for the positivity rate chart to start first.)
+        if not found_first:
+            if record['cumul_tests'] > -1:
+                found_first = True
+                total = record['cumul_tests']
+            continue
+
+        record['date'] = day.isoformat()
+        record['tests'] = record['cumul_tests'] - total
+        total = record['cumul_tests']
+
+        # Estimate positive tests from positivity rate.
+        if record['positivity'] > -1:
+            record['positive'] = round(record['tests'] * record['positivity'])
+            total_positive += record['positive']
+        else:
+            record['positive'] = 0
+        record['cumul_pos'] = total_positive
+
+        result.append(record)
+
+    return result
+
+
+def get_case_totals(api: QlikClient) -> Dict:
+    # Gender and age groups are published as counts, but race and ethnicity are
+    # published as percentages, so we need thet total to calculate counts.
+    gender = get_cases_by_gender(api)
+    total = sum(gender.values())
+
+    return {
+        'gender': gender,
+        'age_group': get_cases_by_age(api),
+        'race_eth': get_cases_by_race(api, total),
+        'ethnicity': get_cases_by_ethnicity(api, total),
+        # No data for these right now:
+        # 'underlying_cond': get_cases_by_condition(api),
+        # 'transmission_cat': get_cases_by_transmission(api),
+    }
+
+
+def get_cases_by_gender(api: QlikClient) -> Dict:
+    gender_data = get_chart_data(api, CHART_IDS['cases_by_gender'])
+    result = {x['qText'].lower(): y['qNum']
+              for x, y in gender_data}
+    try:
+        assert 'male' in result
+        assert 'female' in result
+    except AssertionError:
+        raise FormatError('Missing explicity male/female gender categories '
+                          f'for cases, got: {list(result.keys())}')
+    return result
+
+
+def get_cases_by_age(api: QlikClient) -> List[Dict]:
+    age_data = get_chart_data(api, CHART_IDS['cases_by_age'])
+    return [{'group': x['qText'], 'raw_count': y['qNum']}
+            for x, y in age_data]
+
+
+def get_cases_by_race(api: QlikClient, total: int) -> Dict:
+    raw = get_chart_data(api, CHART_IDS['cases_by_race'])
+    mapping = {
+        'asian': 'Asian',
+        'black or african american': 'African_Amer',
+        'multiple races': 'Multiple_Race',
+        'other': 'Other',
+        'white': 'White',
+        'unknown': 'Unknown',
+    }
+    data = {group['qText'].lower(): round(total * cases['qNum'])
+            for group, _population, cases in raw}
+    assert_equal_sets(mapping.keys(), data.keys())
+    result = {mapping[race]: count
+              for race, count in data.items()}
+    # These are included in "other".
+    result['Native_Amer'] = -1
+    result['Pacific_Islander'] = -1
+    # Latinx is separated out as an ethnicity (unlike other counties, Contra
+    # Costa publishes race and ethnicity separately, rather than as a single,
+    # intersecting set).
+    result['Latinx_or_Hispanic'] = -1
+    return result
+
+
+def get_cases_by_ethnicity(api: QlikClient, total: int) -> Dict:
+    raw = get_chart_data(api, CHART_IDS['cases_by_ethnicity'])
+    mapping = {
+        'hispanic or latino': 'Latinx_or_Hispanic',
+        'not hispanic or latino': 'Other',
+        'unknown': 'Unknown',
+    }
+    data = {group['qText'].lower(): round(total * cases['qNum'])
+            for group, _population, cases in raw}
+    assert_equal_sets(mapping.keys(), data.keys())
+    result = {mapping[race]: count
+              for race, count in data.items()}
+    return result
+
+
+def get_death_totals(api: QlikClient) -> Dict:
+    return {
+        'gender': get_deaths_by_gender(api),
+        'age_group': get_deaths_by_age(api),
+        'race_eth': get_deaths_by_race(api),
+        'ethnicity': get_deaths_by_ethnicity(api),
+        # No data for these right now:
+        # 'underlying_cond': get_deaths_by_condition(api),
+        # 'transmission_cat': get_deaths_by_transmission(api),
+    }
+
+
+def get_deaths_by_gender(api: QlikClient) -> Dict:
+    gender_data = get_chart_data(api, CHART_IDS['deaths_by_gender'])
+    result = {x['qText'].lower(): y['qNum']
+              for x, y in gender_data}
+    try:
+        assert 'male' in result
+        assert 'female' in result
+    except AssertionError:
+        raise FormatError('Missing explicity male/female gender categories '
+                          f'for deaths, got: {list(result.keys())}')
+    return result
+
+
+def get_deaths_by_age(api: QlikClient) -> List[Dict]:
+    age_data = get_chart_data(api, CHART_IDS['deaths_by_age'])
+    return [{'group': x['qText'], 'raw_count': y['qNum']}
+            for x, y in age_data]
+
+
+def get_deaths_by_race(api: QlikClient) -> Dict:
+    raw = get_chart_data(api, CHART_IDS['deaths_by_race'])
+    mapping = {
+        'asian': 'Asian',
+        'black or african american': 'African_Amer',
+        'multiple races': 'Multiple_Race',
+        'other': 'Other',
+        'white': 'White',
+        'unknown': 'Unknown',
+    }
+    data = {group['qText'].lower(): count['qNum']
+            for group, count in raw}
+    assert_equal_sets(mapping.keys(), data.keys())
+    result = {mapping[race]: count
+              for race, count in data.items()}
+    # These are included in "other".
+    result['Native_Amer'] = -1
+    result['Pacific_Islander'] = -1
+    # Latinx is separated out as an ethnicity (unlike other counties, Contra
+    # Costa publishes race and ethnicity separately, rather than as a single,
+    # intersecting set).
+    result['Latinx_or_Hispanic'] = -1
+    return result
+
+
+def get_deaths_by_ethnicity(api: QlikClient) -> Dict:
+    raw = get_chart_data(api, CHART_IDS['deaths_by_ethnicity'])
+    mapping = {
+        'hispanic or latino': 'Latinx_or_Hispanic',
+        'not hispanic or latino': 'Other',
+        'unknown': 'Unknown',
+    }
+    data = {group['qText'].lower(): count['qNum']
+            for group, count in raw}
+    assert_equal_sets(mapping.keys(), data.keys())
+    result = {mapping[race]: count
+              for race, count in data.items()}
+    return result

--- a/covid19_sfbayarea/data/contra_costa.py
+++ b/covid19_sfbayarea/data/contra_costa.py
@@ -173,8 +173,9 @@ def get_timeseries_deaths(api: QlikClient) -> List[dict]:
             'date': day.isoformat(),
             'deaths': deaths,
             'cumul_deaths': total,
-            'ltcf_deaths': ltcf['qNum'],
-            'non_ltcf_deaths': non_ltcf['qNum'],
+            # TODO: consider adding these for counties that include them?
+            # 'ltcf_deaths': ltcf['qNum'],
+            # 'non_ltcf_deaths': non_ltcf['qNum'],
         })
 
     return results

--- a/covid19_sfbayarea/data/contra_costa.py
+++ b/covid19_sfbayarea/data/contra_costa.py
@@ -41,7 +41,7 @@ Overview - https://www.coronavirus.cchealth.org/overview
            https://dashboard.cchealth.org/extensions/COVIDDashboard/Overview.html
            ID: b7d7f869-fb91-4950-9262-0b89473ceed6
 
-Vavvines - https://www.coronavirus.cchealth.org/vaccine
+Vaccines - https://www.coronavirus.cchealth.org/vaccine
            ID: 8dea25ae-3782-48ef-9199-508a3163297e
 """
 

--- a/covid19_sfbayarea/data/qlik.py
+++ b/covid19_sfbayarea/data/qlik.py
@@ -3,7 +3,7 @@ import json
 import logging
 from types import TracebackType
 from typing import Any, Dict, List, Union, Optional, Type
-from websocket import create_connection
+from websocket import create_connection  # type: ignore
 
 
 logger = logging.getLogger(__name__)

--- a/covid19_sfbayarea/data/qlik.py
+++ b/covid19_sfbayarea/data/qlik.py
@@ -1,0 +1,196 @@
+from datetime import date, timedelta
+import json
+import logging
+from types import TracebackType
+from typing import Any, Dict, List, Union, Optional, Type
+from websocket import create_connection
+
+
+logger = logging.getLogger(__name__)
+
+
+class JsonRpcError(Exception):
+    def __init__(self, code: int, message: str, **data: Dict):
+        self.code = code
+        self.message = message
+        self.data = data
+        reason = f'{message} (code {code})'
+        if data:
+            reason += f' -- {data}'
+
+        super().__init__(reason)
+
+
+class QlikClient:
+    """
+    Qlik (https://qlik.com/) exposes its main dashboard/client API over
+    WebSockets with a JSON-RPC-based protocol (it's not *quite* standard, and
+    includes `handle` and `delta` properties that are critically important but
+    not part of JSON-RPC).
+
+    This is a pretty thin wrapper around the basics of the API. We might want
+    to extend it as we learn more about the detailed patterns in various Qlik
+    objects or in the Counties' typical setups.
+
+    Qlik Engine Docs: https://help.qlik.com/en-US/sense-developer/November2020/Subsystems/EngineAPI/Content/Sense_EngineAPI/introducing-engine-API.htm
+                 And: https://help.qlik.com/en-US/sense-developer/November2020/APIs/EngineAPI/index.html
+    JSON-RPC docs: https://www.jsonrpc.org/specification
+
+    There are some existing Python Clients, but they all either don't seem well
+    maintained or don't appear to cover the API aspects we focus on.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the Qlik server, e.g.
+        ``'wss://dashboard.cchealth.org/app/'``.
+    document_id : str
+        The ID of the document you want to read data from, e.g.
+        ``'b7d7f869-fb91-4950-9262-0b89473ceed6'``.
+
+    Examples
+    --------
+    Connect and get an object:
+    >>> dashboard = QlikClient('wss://dashboard.cchealth.org/app/',
+    >>>                        'b7d7f869-fb91-4950-9262-0b89473ceed6')
+    >>> dashboard.open()
+    >>> tests_chart = dashboard.get_data('bZFxmu')
+    """
+    def __init__(self, url: str, document_id: str, cookie: str = None):
+        self.url = url + ('' if url.endswith('/') else '/')
+        self.document_id = document_id
+        self._message_id = 1
+        self._document_handle = -1
+        self._cookie = cookie
+
+    def _connect(self) -> None:
+        "Connect to the websocket server."
+        socket_url = self.url + self.document_id
+        self._socket = create_connection(socket_url, cookie=self._cookie)
+
+    def _send(self, handle: Any, method: str, parameters: Union[List, Dict],
+              delta: bool = False) -> Dict:
+        "Send a JSON-RPC message and await the response."
+        id_ = self._message_id
+        self._message_id += 1
+
+        message = {
+            'jsonrpc': '2.0',
+            'id': id_,
+            # `handle` is non-standard, but required in Qlik's API.
+            'handle': handle,
+            'method': method,
+            'params': parameters
+        }
+        # `delta` is also non-standard, and an optional part of the API.
+        if delta:
+            message['delta'] = True
+
+        logger.debug('Sending: %s', message)
+        self._socket.send(json.dumps(message))
+
+        while True:
+            # Keep reading the socket until we see our response.
+            response = self._socket.recv()
+            logger.debug('Received: %s', response)
+            response_data = json.loads(response)
+            if response_data.get('id') == id_:
+                break
+
+        if 'error' in response_data:
+            raise JsonRpcError(**response_data['error'])
+        elif 'result' in response_data:
+            return response_data['result']
+        elif 'method' in response_data:
+            return {
+                'method': response_data['method'],
+                'params': response_data.get('params')
+            }
+        else:
+            raise ValueError(f'Unexpected response: {response_data}')
+
+    def open(self) -> None:
+        "Open a connection to the Qlik server and get basic document info."
+        self._connect()
+        document = self._send(-1,
+                              'OpenDoc',
+                              [self.document_id, "", "", "", False])
+        self._document_handle = document['qReturn']['qHandle']
+
+    def close(self) -> None:
+        self._socket.close()
+
+    def get_app_layout(self) -> Dict:
+        """
+        Get layout information for application/document as a whole.
+        """
+        return self._send(self._document_handle, 'GetAppLayout', [])
+
+    def get_object(self, object_id: str) -> Dict:
+        """
+        Get a handle for the object with a given ID. In most cases, you want to
+        call ``get_data`` instead (it gets full details instead of a handle).
+
+        Parameters
+        ----------
+        object_id : str
+            The ID of the object to get a handle to, e.g. ``'bZFxmu'``.
+        """
+        return self._send(self._document_handle, 'GetObject', [object_id])
+
+    def get_layout(self, handle: Any) -> Dict:
+        """
+        Get layout information for the object with a given handle. In most
+        cases, you want to call ``get_data`` instead (it takes the object ID
+        instead of a handle).
+
+        Parameters
+        ----------
+        handle
+            The API handle of the object to get.
+        """
+        return self._send(handle, 'GetLayout', [])
+
+    def get_data(self, object_id: str) -> Dict:
+        """
+        Get detailed information for an object in the Qlik document. This
+        usually includes layout/styling info, formatting info, and data (in the
+        case of tables, charts, etc.).
+
+        Parameters
+        ----------
+        object_id : str
+            The ID of the object to get data for, e.g. ``'bZFxmu'``.
+        """
+        handle = self.get_object(object_id)['qReturn']['qHandle']
+        return self.get_layout(handle)
+
+    def get_field(self, field: str) -> Dict:
+        return self._send(self._document_handle, 'GetField', [field])
+
+    def select_field_value(self, field: str, value: str) -> Dict:
+        handle = self.get_field(field)['qReturn']['qHandle']
+        return self._send(handle, 'Select', [value])
+
+    def __enter__(self) -> 'QlikClient':
+        self.open()
+        return self
+
+    def __exit__(self,
+                 _type: Optional[Type[BaseException]],
+                 _value: Optional[BaseException],
+                 _traceback: Optional[TracebackType]) -> None:
+        self.close()
+
+    @staticmethod
+    def parse_date(value: int) -> date:
+        """
+        Parse a date from Qlik. Qlik uses MS Excel's date format
+        (days since 1900-01-01 + 2).
+
+        Parameters
+        ----------
+        value : int
+            The Qlik/Excel-formatted date value to parse.
+        """
+        return date(1900, 1, 1) + timedelta(days=(value - 2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ requests==2.23.0
 selenium==3.141.0
 urllib3==1.25.8
 webdrivermanager==0.8.0
+websocket-client==0.57.0
 Werkzeug==1.0.0


### PR DESCRIPTION
There are quite a few complexities and caveats with this one:

- Positive test counts are estimated based on rate (since the county only publishes the rate), similar to Santa Clara.

- Daily test counts, total test counts, and test positivity rates are each separate charts that cover different date ranges! Putting them together as a single series is a bit messy. Worse, daily test counts and totals don't completely agree (the total tests series starts earlier, and roughly the first two weeks of daily tests have `0` for the value, while the difference between total tests on those days is often > 0). After March 18, 2020 they mostly agree, so daily total test counts seems like the better source. I've calculated daily tests based on the difference between days in total tests, rather than using the daily counts directly.

- Contra Costa splits out hispanic ethnicity from the other racial categories, unlike all the other counties, which provide them as a combined cross section. I'm not sure there's a good way to make our own combined version, so I added an new grouping for `ethnicity`, and left the other races in `race_eth` as usual. It's not great for comparing to other counties. (Maybe we could assume "hispanic" is a chunk out of "white" and calculate the cross section that way, but that seems pretty iffy. I'm open to feedback or suggestions.)

- Case race and case ethnicity are published as percentages, unlike the other case demographics and the corresponding death demographics, so I've calculated them based on the totals. Kind of a weird exception (especially since the same thing isn't done for deaths).

Fixes #21.