### PR TITLE
HOTFIX: San Mateo tests table was renamed

### DIFF
--- a/covid19_sfbayarea/data/san_mateo/time_series_tests.py
+++ b/covid19_sfbayarea/data/san_mateo/time_series_tests.py
@@ -8,8 +8,8 @@ class TimeSeriesTests(PowerBiQuerier):
         self.model_id = 275728
         self.powerbi_resource_key = '1b96a93b-9500-44cf-a3ce-942805b455ce'
         self.source = 'l'
-        self.name = 'lab_cases_by_date'
-        self.property = 'lab_collection_date'
+        self.name = 'lab_tests_by_day'
+        self.property = 'early_spec_date'
         super().__init__()
 
     def _parse_data(self, response_json: Dict) -> List[Dict[str, Any]]:
@@ -44,10 +44,10 @@ class TimeSeriesTests(PowerBiQuerier):
                 'Column': self._column_expression(self.property),
                 'Name': f'{self.name}.{self.property}'
             },
-            self._aggregation('positive_per_day'),
-            self._aggregation('unknown_per_day'),
-            self._aggregation('negative_per_day')
-       ]
+            self._aggregation('Positive'),
+            self._aggregation('Inconclusive'),
+            self._aggregation('Negative')
+        ]
 
     def _binding(self) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
It looks like someone renamed the table and columns for test data in San Mateo, which broke the scraper. I've updated with the new names and verified that the data looks at least *roughly* like it used to. (It seems the timeseries now starts a month later than it used to, though. I tried using a `Where` clause to extend it, but no dice. This is just all that's there now.)

This fixes the broken scrapes we are currently experiencing for San Mateo, e.g. https://sfbrigade.slack.com/archives/C01AV92EM47/p1615198414000100