### PR TITLE
HOTFIX: Point hospitalization data scraper to new CHHS API resource

### DIFF
--- a/covid19_sfbayarea/data/hospitals.py
+++ b/covid19_sfbayarea/data/hospitals.py
@@ -16,9 +16,9 @@ from .ckan import Ckan
 
 
 # URLs and APIs
-HOSPITALS_LANDING_PAGE = "https://data.ca.gov/dataset/covid-19-hospital-data#"
-CAGOV_BASEURL = "https://data.ca.gov"
-HOSPITALS_RESOURCE_ID = "42d33765-20fd-44b8-a978-b083b7542225"
+HOSPITALS_LANDING_PAGE = "https://data.chhs.ca.gov/dataset/covid-19-hospital-data"
+CAGOV_BASEURL = "https://data.chhs.ca.gov"
+HOSPITALS_RESOURCE_ID = "47af979d-8685-4981-bced-96a6b79d3ed5"
 RESULTS_LIMIT = 200
 
 # For the output data
@@ -71,7 +71,12 @@ def floats_to_ints(record: Dict) -> Dict:
             continue
 
         else:
-            record[field] = int(val)
+            try:
+                record[field] = int(val)
+
+            except ValueError:
+                # Handle floats stored as strings
+                record[field] = int(float(val))
 
     return record
 


### PR DESCRIPTION
Per [data.ca.gov](https://data.ca.gov/dataset/covid-19-hospital-data#), that CKAN resource has been deprecated and replaced by one provided by CHHS. The values and the structure appear to be mostly the same, so this hotfix mainly just points our code to the new resource.

One note: It looks like the CHHS resource doesn't return as much meta data about each of the fields as the prior CA.gov resource. Here's what the raw data looks like for the `fields` key:

```javascript
"fields": [
    {"type": "int", "id": "_id"}, 
    {"type": "text", "id": "county"}, 
    {"type": "text", "id": "todays_date"},
    {"type": "text", "id": "hospitalized_covid_confirmed_patients"}, 
    {"type": "text", "id": "hospitalized_suspected_covid_patients"}, 
    {"type": "text", "id": "hospitalized_covid_patients"}, 
    {"type": "text", "id": "all_hospital_beds"}, 
    {"type": "text", "id": "icu_covid_confirmed_patients"}, 
    {"type": "text", "id": "icu_suspected_covid_patients"}, 
    {"type": "text", "id": "icu_available_beds"}
]
```
I don't think that's super critical, since we're not really using most of those values on the front end anyhow, but worth being aware of. 

In addition, I spotted two other things: 

* After diffing the data from CHHS with the latest pull that we had from the prior CA.gov resource, I noticed that the `_id` field values are different for same given date, for the given county. Probably to be expected and of no consequence for our purposes.

* Floats are being represented as strings in the raw data (as one might infer from the "text" type in the field descriptions), which we previously hadn't encountered but I've now added handling for.

This script still needs some logging for automated alerts; I figure that can be handled in a separate PR.

Fixes #187 