### PR TITLE
HOTFIX: Get San Mateo deaths by day from LA Times

### DIFF
--- a/covid19_sfbayarea/data/san_mateo/__init__.py
+++ b/covid19_sfbayarea/data/san_mateo/__init__.py
@@ -2,7 +2,7 @@ import csv
 import json
 import requests
 
-from datetime import datetime, date
+from datetime import datetime
 from typing import Any, Dict, List, cast
 from covid19_sfbayarea.utils import dig, parse_datetime
 

--- a/covid19_sfbayarea/data/san_mateo/__init__.py
+++ b/covid19_sfbayarea/data/san_mateo/__init__.py
@@ -1,4 +1,6 @@
+import csv
 import json
+import requests
 
 from datetime import datetime, date
 from typing import Any, Dict, List, cast
@@ -17,8 +19,8 @@ from .deaths_by_gender import DeathsByGender
 from .time_series_cases import TimeSeriesCases
 from .time_series_tests import TimeSeriesTests
 
-from ..ckan import Ckan
 from ..utils import get_data_model
+from ...errors import FormatError
 
 LANDING_PAGE = 'https://www.smchealth.org/post/san-mateo-county-covid-19-data-1'
 
@@ -34,16 +36,15 @@ def fetch_data() -> Dict:
         'meta_from_source': Meta().get_data(),
         'meta_from_baypd': """
             See power_bi_scraper.py for methods.
-            San Mateo does not provide a timestamp for their last dataset update,
-            so BayPD uses midnight of the latest day in the cases timeseries as a proxy.
+            San Mateo does not provide a timestamp for their last dataset
+            update, so BayPD uses midnight of the latest day in the cases
+            timeseries as a proxy.
 
             San Mateo does not provide a deaths timeseries. Instead, the deaths
-            timeseries is pulled from CHHS’s statewide data portal at
-            https://data.chhs.ca.gov/. Deaths for which a date is not yet
-            determined are included in the latest date of the timeseries.
-            Please note that, because data is coming from disparate sources,
-            total count of deaths may not add up between the timeseries (from
-            CHHS) and the demographic data (from the county).
+            timeseries is from data published by LA Times, which appears to be
+            built by saving the county's listed total each day. See more on the
+            LA Times data at:
+            https://github.com/datadesk/california-coronavirus-data
          """,
         'series': {
             'cases': TimeSeriesCases().get_data(),
@@ -73,49 +74,37 @@ def most_recent_case_time(data: Dict[str, Any]) -> datetime:
 
 def get_timeseries_deaths() -> List:
     """
-    Get a timeseries of deaths by day from the state (since they county does
-    not publish this info). View the dataset in a browser at:
-    https://data.chhs.ca.gov/dataset/covid-19-time-series-metrics-by-county-and-state/resource/046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a
-    """
-    state_api = Ckan('https://data.chhs.ca.gov')
-    records = state_api.data('046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a',
-                             filters={'area': 'San Mateo'},
-                             sort='date asc')
-    # Rows in this dataset include `deaths` and `reported_deaths`, neither of
-    # which is a total. The data dictionary does not describe the specifics
-    # around these, but they appear to be deaths attributed to a given day and
-    # then the day there actually *reported* to the state.
-    total_deaths = 0
-    timeseries: List[Dict[str, Any]] = []
-    unknown_date_deaths = 0
-    for record in records:
-        deaths = int(float(record['deaths']))
-        # There is one entry with no date for records that do not (yet) have an
-        # identified date. Hold on to it for adding at the end.
-        if record['date']:
-            total_deaths += deaths
-            timeseries.append({
-                'date': parse_datetime(record['date']).date().isoformat(),
-                'deaths': deaths,
-                'cumul_deaths': total_deaths
-            })
-        else:
-            unknown_date_deaths = deaths
+    Get a timeseries of deaths by day from LA Times (since the county does not
+    publish a timeseries). Their data appears to track the day-to-day totals
+    from the county, while other sources we have used do not. Notably, the
+    state no longer publishes this data at all.
 
-    # Attribute unknown date deaths to today.
-    if unknown_date_deaths:
-        total_deaths += unknown_date_deaths
-        today = date.today().isoformat()
-        latest_entry = timeseries[-1]
-        if latest_entry['date'] == today:
-            latest_entry['deaths'] += unknown_date_deaths
-            latest_entry['cumul_deaths'] += total_deaths
-        else:
-            timeseries.append({
-                'date': today,
-                'deaths': unknown_date_deaths,
-                'cumul_deaths': total_deaths
-            })
+    Because the LA Times data has generally matched the county dashboard, it
+    should be fairly consistent with the rest of our data. View the dataset in
+    a browser at:
+    https://github.com/datadesk/california-coronavirus-data/blob/master/latimes-county-totals.csv
+    """
+    timeseries: List[Dict[str, Any]] = []
+    url = 'https://raw.githubusercontent.com/datadesk/california-coronavirus-data/master/latimes-county-totals.csv'
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        lines = (line.decode('utf-8') for line in response.iter_lines())
+        for row in csv.DictReader(lines):
+            if row['county'] == 'San Mateo':
+                timeseries.append({
+                    'date': row['date'],
+                    'deaths': int(row['new_deaths'] or 0),
+                    'cumul_deaths': int(row['deaths'] or 0),
+                })
+
+    timeseries.sort(key=lambda row: row['date'])
+
+    # Sanity-check the results.
+    total = 0
+    for entry in timeseries:
+        total += entry['deaths']
+        if total != entry['cumul_deaths']:
+            raise FormatError(f'Death totals do not match in {entry}')
 
     return timeseries
 


### PR DESCRIPTION
The state has ceased publishing COVID-19 deaths as a timeseries, so we need to load the data from another source. LA Times's data appears to have been more consistent with the county than the data we were previously loading from CHHS, so this not only is a hotfix, but probably improves our data quality anyway.

Fixes #190.