### PR TITLE
HOTFIX: Some Contra Costa headings aren't headings

### DIFF
--- a/covid19_sfbayarea/news/contra_costa.py
+++ b/covid19_sfbayarea/news/contra_costa.py
@@ -108,10 +108,11 @@ class ContraCostaNews(NewsScraper):
         soup = BeautifulSoup(html, 'lxml')
         base_url = get_base_url(soup, url)
         news = []
-        month_headings = soup.find_all(self.is_news_heading)
+        containers = set([heading.parent
+                          for heading in soup.find_all(self.is_news_heading)])
         index = 0
-        for heading in month_headings:
-            articles = self.get_next_list(heading).find_all('li')
+        for container in containers:
+            articles = container.find_all('li')
             for article in articles:
                 index += 1
                 item = self.parse_article(index,


### PR DESCRIPTION
The Contra Costa news scraper recently stopped picking up a lot of news stories because some of the month headings on the news page are no longer actual headings (instead they are a `<p>` with several nested `<span>` inside it). The new code still relies on *some* of them being properly marked up as headings, but not all. Instead of looking for the list of news items after each month heading, we find the parent elements of the headings, and look for all list items in them.