### PR TITLE
HOTFIX: Handle pagination for SocrataApi so all data is fetched for Marin

### DIFF
--- a/covid19_sfbayarea/data/marin.py
+++ b/covid19_sfbayarea/data/marin.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Iterable
 from datetime import datetime
 from ..errors import FormatError
 from ..utils import assert_equal_sets, parse_datetime
-from .utils import SocrataApi
+from .socrata import SocrataApi
 
 
 API_IDS = {

--- a/covid19_sfbayarea/data/san_francisco.py
+++ b/covid19_sfbayarea/data/san_francisco.py
@@ -3,7 +3,8 @@ import json
 from typing import Any, Dict, List
 from collections import Counter
 from ..utils import assert_equal_sets
-from .utils import get_data_model, SocrataApi
+from .utils import get_data_model
+from .socrata import SocrataApi
 
 def get_county() -> Dict:
     """ Main method for populating county data.json """

--- a/covid19_sfbayarea/data/santa_clara.py
+++ b/covid19_sfbayarea/data/santa_clara.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Dict, List
 from ..errors import FormatError
 from ..utils import assert_equal_sets, parse_datetime
-from .utils import SocrataApi
+from .socrata import SocrataApi
 
 
 API_IDS = {

--- a/covid19_sfbayarea/data/socrata.py
+++ b/covid19_sfbayarea/data/socrata.py
@@ -1,0 +1,84 @@
+from functools import lru_cache
+from typing import Any, Dict, List
+import requests
+from urllib.parse import urljoin
+from cachecontrol import CacheControl  # type: ignore
+from ..errors import BadRequest
+
+
+class SocrataApi:
+    """
+    Class for starting a session for requests via Socrata APIs.
+    Initialize with a base_url
+    """
+    # SODA API has a default limit of 1000 records per call,
+    # so we'll use that as well.
+    # See: https://dev.socrata.com/docs/paging.html
+    DEFAULT_LIMIT = 1000
+
+    def __init__(self, base_url: str):
+        self.session = CacheControl(requests.Session())
+        self.base_url = base_url
+        self.resource_url = urljoin(self.base_url, '/resource/')
+        self.metadata_url = urljoin(self.base_url, '/api/views/metadata/v1/')
+
+    @lru_cache(maxsize=32)
+    def _request(self, url: str, **kwargs: Any) -> Dict:
+        try:
+            response = self.session.get(url, **kwargs)
+            response.raise_for_status()
+            return response.json()
+
+        except requests.exceptions.HTTPError as http_err:
+
+            try:
+                # see if the API returned message data
+                server_message = response.json()['message']
+
+            except Exception:
+                # if no JSON data, re-rasie the original error
+                raise http_err
+
+            raise BadRequest(server_message, response=response)
+
+    def request(self, url: str, params: Dict = None, **kwargs: Any) -> Dict:
+        # Arguments to _request() must be hashable (so they can be cached).
+        # If a params dict is sent, convert it to a tuple.
+        if params:
+            kwargs['params'] = tuple(params.items())
+
+        return self._request(url, **kwargs)
+
+    def resource(
+            self, resource_id: str, params: Dict = None, **kwargs: Any
+    ) -> List[Dict]:
+        """Fetch and return data from a given Socrata data resource"""
+        data: List[Dict] = []
+
+        params = params or {}
+        params.setdefault("$offset", 0)
+        limit = params.setdefault("$limit", self.DEFAULT_LIMIT)
+
+        while True:
+            results = self.request(
+                f'{self.resource_url}{resource_id}', params=params, **kwargs
+            )
+            result_count = len(results)
+
+            if result_count == limit:
+                data.extend(results)
+                offset = params["$offset"] + limit
+                params.update({"$offset": offset})
+                continue
+
+            elif result_count > 0 and result_count < limit:
+                data.extend(results)
+                break
+
+            else:
+                break
+
+        return data
+
+    def metadata(self, resource_id: str, **kwargs: Any) -> Dict:
+        return self.request(f'{self.metadata_url}{resource_id}.json', **kwargs)

--- a/covid19_sfbayarea/data/utils.py
+++ b/covid19_sfbayarea/data/utils.py
@@ -1,11 +1,7 @@
-from functools import lru_cache
-from pathlib import Path
 import json
-from typing import Any, Dict, List
-import requests
-from urllib.parse import urljoin
-from cachecontrol import CacheControl  # type: ignore
-from ..errors import BadRequest
+from pathlib import Path
+from typing import Dict
+
 
 def get_data_model() -> Dict:
     """ Return a dictionary representation of the data model """
@@ -14,70 +10,3 @@ def get_data_model() -> Dict:
     with template_path.open() as template:
         out = json.load(template)
     return out
-
-class SocrataApi:
-    """
-    Class for starting a session for requests via Socrata APIs.
-    Initialize with a base_url
-    """
-    # SODA API has a default limit of 1000 records per call,
-    # so we'll use that as well.
-    # See: https://dev.socrata.com/docs/paging.html
-    DEFAULT_LIMIT = 1000
-
-    def __init__(self, base_url: str):
-        self.session = CacheControl(requests.Session())
-        self.base_url = base_url
-        self.resource_url = urljoin(self.base_url, '/resource/')
-        self.metadata_url = urljoin(self.base_url, '/api/views/metadata/v1/')
-
-    @lru_cache(maxsize=32)
-    def _request(self, url: str, **kwargs: Any) -> Dict:
-        try:
-            response = self.session.get(url, **kwargs)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.HTTPError as http_err:
-            try:
-                server_message = response.json()['message'] # see if the API returned message data
-            except Exception:
-                # if no JSON data, re-rasie the original error
-                raise http_err
-            raise BadRequest(server_message, response=response)
-
-    def request(self, url: str, params: Dict = None, **kwargs: Any) -> Dict:
-        # Arguments to _request() must be hashable (so they can be cached).
-        # If a params dict is sent, convert it to a tuple.
-        if params:
-            kwargs['params'] = tuple(params.items())
-
-        return self._request(url, **kwargs)
-
-    def resource(self, resource_id: str, params: Dict = None, **kwargs: Any) -> List[Dict]:
-        data: List[Dict] = []
-
-        params = params or {}
-        params.setdefault("$offset", 0)
-        params.setdefault("$limit", self.DEFAULT_LIMIT)
-
-        while True:
-            results = self.request(f'{self.resource_url}{resource_id}', params=params, **kwargs)
-            result_count = len(results)
-
-            if result_count == self.DEFAULT_LIMIT:
-                data.extend(results)
-                offset = params["$offset"] + self.DEFAULT_LIMIT
-                params.update({"$offset": offset})
-                continue
-
-            elif result_count > 0 and result_count < self.DEFAULT_LIMIT:
-                data.extend(results)
-                break
-
-            else:
-                break
-
-        return data
-
-    def metadata(self, resource_id: str, **kwargs: Any) -> Dict:
-        return self.request(f'{self.metadata_url}{resource_id}.json', **kwargs)

--- a/covid19_sfbayarea/data/utils.py
+++ b/covid19_sfbayarea/data/utils.py
@@ -53,27 +53,21 @@ class SocrataApi:
 
         return self._request(url, **kwargs)
 
-    def resource(self, resource_id: str, **kwargs: Any) -> List[Dict]:
+    def resource(self, resource_id: str, params: Dict = None, **kwargs: Any) -> List[Dict]:
         data: List[Dict] = []
 
-        if "params" in kwargs:
-            if "$offset" not in kwargs["params"]:
-                kwargs["params"].update({"$offset": 0})
-
-            else:
-                pass
-
-        else:
-            kwargs["params"] = {"$offset": 0}
+        params = params or {}
+        params.setdefault("$offset", 0)
+        params.setdefault("$limit", self.DEFAULT_LIMIT)
 
         while True:
-            results = self.request(f'{self.resource_url}{resource_id}', **kwargs)
+            results = self.request(f'{self.resource_url}{resource_id}', params=params, **kwargs)
             result_count = len(results)
 
             if result_count == self.DEFAULT_LIMIT:
                 data.extend(results)
-                offset = kwargs["params"].get("$offset") + self.DEFAULT_LIMIT
-                kwargs["params"].update({"$offset": offset})
+                offset = params["$offset"] + self.DEFAULT_LIMIT
+                params.update({"$offset": offset})
                 continue
 
             elif result_count > 0 and result_count < self.DEFAULT_LIMIT:


### PR DESCRIPTION
This is a hotfix to implement pagination when fetching data via the `resource()` method of the `SocrataApi()` class. The absence of pagination limits the number of records fetched for a given county, which is currently noticeable for Marin on the front-end.

Fixes #203 