### PR TITLE
HOTFIX: Alameda news has language link as summary

### DIFF
--- a/covid19_sfbayarea/news/alameda.py
+++ b/covid19_sfbayarea/news/alameda.py
@@ -325,6 +325,8 @@ class ItemParser:
         elif (node.name == 'a'
               and node.get_text(strip=True).lower() == 'english'):
             self.item.url = node['href']
+            # Skip to the next thing after the link
+            raise SkipIterationTo(list(node.descendants)[-1].next_element)
 
     def parse_br(self, node: element.Tag) -> None:
         """

--- a/tests/news/alameda_test.py
+++ b/tests/news/alameda_test.py
@@ -64,3 +64,34 @@ def test_parses_titles_with_single_word_links() -> None:
             date_published=datetime(2020, 9, 28, tzinfo=PACIFIC_TIME),
             summary=''
         ) == feed.items[0]
+
+
+def test_has_no_summary_when_br_in_language_links() -> None:
+    # This is a stripped-down version of the Alameda page's current markup,
+    # which may change.
+    mock_html = """<!DOCTYPE html>
+        <html>
+            <body>
+                <div id="mainCol">
+                    <strong>September 28, 2020</strong>
+                    This is the title (with no summary)
+                    <a href="/link-english.html" target="_blank">
+                        <br>
+                        English
+                    </a>
+                    |
+                    <a href="/link-spanish.html" target="_blank">Spanish</a>
+                </div>
+            </body>
+        </html>
+    """
+    with patch.object(AlamedaNews, 'load_html', return_value=mock_html):
+        feed = AlamedaNews.get_news()
+        assert 1 == len(feed.items)
+        assert NewsItem(
+            id='https://covid-19.acgov.org/link-english.html',
+            url='https://covid-19.acgov.org/link-english.html',
+            title='This is the title (with no summary)',
+            date_published=datetime(2020, 9, 28, tzinfo=PACIFIC_TIME),
+            summary=''
+        ) == feed.items[0]


### PR DESCRIPTION
One of the news items on the Alameda news page has a `<br>` tag inside one of the language-specific links for the news item. This is causing the parser to flip back to the summary parsing state and read the text of the link as the news item's summary. This fixes the issue by jumping to the next sibling of the language link after parsing it, rather than unnecessarily moving *inside* the link. (Usually that’s no issue, because the text inside the link doesn't cause any special behavior.)