### PR TITLE
HOTFIX: Disable scraper functions for discontinued Sonoma gender data

### DIFF
--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -314,12 +314,17 @@ def get_county() -> Dict:
     # now we calculate the the sum of the cases across all age groups
     total_cases = sum([int(group['raw_count']) for group in transform_age(cases_by_age)])
 
+    meta_from_baypd = (
+        "On or about 2021-06-03, Sonoma County stopped providing case totals "
+        "by gender. Null values are inserted as placeholders for consistency."
+    )
+
     model = {
         'name': 'Sonoma County',
         'update_time': datetime.now(timezone.utc).isoformat(),
         'source_url': url,
         'meta_from_source': get_source_meta(sonoma_soup),
-        'meta_from_baypd': '',
+        'meta_from_baypd': meta_from_baypd,
         'series': transform_cases(hist_cases),
         'case_totals': {
             'transmission_cat': transform_transmission(cases_by_source, total_cases),

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -312,7 +312,7 @@ def get_county() -> Dict:
     # calculate total cases to compute values from percentages
     # we previously summed the cases across all genders, but with gender data unavailable,
     # now we calculate the the sum of the cases across all age groups
-    total_cases = sum([group['raw_count'] for group in transform_age(cases_by_age)])
+    total_cases = sum([int(group['raw_count']) for group in transform_age(cases_by_age)])
 
     model = {
         'name': 'Sonoma County',

--- a/covid19_sfbayarea/data/sonoma.py
+++ b/covid19_sfbayarea/data/sonoma.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import dateutil.parser
+from datetime import datetime, timezone
 from typing import List, Dict, Union
 from bs4 import BeautifulSoup, element # type: ignore
 from ..errors import FormatError
@@ -65,18 +66,6 @@ def parse_int(text: str) -> int:
         return 0
     else:
         return int(text.replace(',', ''))
-
-def generate_update_time(soup: BeautifulSoup) -> str:
-    """
-    Finds and parses an ISO 8601 timestamp string for when the page was last updated
-    """
-    update_time_text = soup.find('meta', {'property': 'article:modified_time'})['content']
-    try:
-        date = dateutil.parser.parse(update_time_text)
-    except ValueError:
-        raise ValueError(f'Date is not in ISO 8601'
-                         f'format: "{update_time_text}"')
-    return date.isoformat()
 
 def get_source_meta(soup: BeautifulSoup) -> str:
     """
@@ -327,7 +316,7 @@ def get_county() -> Dict:
 
     model = {
         'name': 'Sonoma County',
-        'update_time': generate_update_time(sonoma_soup),
+        'update_time': datetime.now(timezone.utc).isoformat(),
         'source_url': url,
         'meta_from_source': get_source_meta(sonoma_soup),
         'meta_from_baypd': '',


### PR DESCRIPTION
Sonoma County no longer provides a breakdown of cases by gender on its dashboard, or anywhere else that we can seem to find. Because that data is missing, our scraper has been failing. This set of changes disables the pieces of code that look for that gender table, and inserts a placeholder object with null values for cases by gender for the sake of consistency and compatibility. I've left most of the code in the scraper in case the county restores this table.

Fixes #213 

I've also taken this opportunity to remove the part of the code that tried to extract the latest update time from the page metadata, as that timestamp no longer seems reliable.

Fixes #205 