### PR TITLE
Remove warning about no disclaimers in Solano

### DIFF
--- a/covid19_sfbayarea/data/solano.py
+++ b/covid19_sfbayarea/data/solano.py
@@ -137,15 +137,10 @@ def get_notes() -> str:
         driver.implicitly_wait(30)
         driver.get(dashboard_url)
         soup = BeautifulSoup(driver.page_source, 'html5lib')
-        has_notes = False
         text = soup.get_text().splitlines()
         for text_item in text:
             if match.search(text_item):
                 notes.append(text_item.strip())
-                has_notes = True
-        if not has_notes:
-            logger.warn('None of the elements on the dashboard contain '
-                        f'"disclaimer?" ({dashboard_url})')
         return '\n\n'.join(notes)
 
 


### PR DESCRIPTION
Right now, we get this message on the #proj-covid-alerts channel every day, and it’s not actually very useful:

> None of the elements on the dashboard contain "disclaimer?" (https://doitgis.maps.arcgis.com/apps/opsdashboard/index.html#/d28335cd317a45cd84211cd290889c27)

It’s coming from Solano County scraper and isn't really signifying a problem, but it logs every night when we scrape and makes it appear as if there *is* a problem. I’ve simply removed the warning.

