### PR TITLE
HOTFIX: messy data in Santa Clara and Contra Costa

### DIFF
--- a/covid19_sfbayarea/data/contra_costa.py
+++ b/covid19_sfbayarea/data/contra_costa.py
@@ -152,10 +152,16 @@ def get_timeseries_cases(api: QlikClient) -> List[dict]:
     # Sanity-check daily cases vs. totals
     total = 0
     for index, record in enumerate(result):
-        # We can't find a reliable county-level source that covers all time, so
-        # so the total cases on the first day of the timeseries may include
-        # past cases, and can't be reconciled with any other data.
-        if index == 0:
+        # The county's dataset does a funny thing: on the first date that has
+        # cases, the cumulative case count is higher than the day's case count.
+        # This looks like it might be because the dataset doesn't reach all the
+        # way back to the first case, and something along the way in their
+        # data pipeline doesn't output the cumulative count until there's a day
+        # with a positive count.
+        #
+        # That means the case count and total count on the first day with a
+        # case can't be reconciled, so just take whatever total it tells us.
+        if total == 0:
             total = record['cumul_cases']
         else:
             total += record['cases']

--- a/scraper_data.py
+++ b/scraper_data.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import click
 import json
+import logging
+import os
 from covid19_sfbayarea import data as data_scrapers
 from covid19_sfbayarea.utils import friendly_county
 from sys import exit
@@ -48,4 +50,5 @@ def main(counties: Tuple[str,...], output: str) -> None:
     if failed_counties: exit(1) # some counties failed
 
 if __name__ == '__main__':
+    logging.basicConfig(level=os.getenv('LOG_LEVEL', 'WARN').upper())
     main()


### PR DESCRIPTION
This fixes issues that have cropped up in two counties (Santa Clara and Contra Costa) that are breaking their scrapers:

- In Contra Costa, the specifics of the issue I worked around in #217 have changed slightly -- now the first day with data is prefixed by a month of records with case counts of 0. It seems like these are probably fake, since the first day with data still exhibits the same problem that the first day used to, that its total is clearly accounting for some earlier records that are not shown in the public data we can see. The fix is basically the same, except it's no longer about the *first* day; it's about the first day with non-zero data.

- In Santa Clara, the final row has no date. Since it's only one row and will hopefully be fixed on the county's side, I've changed the code to just skip the record and log a warning, but otherwise operate fine. If the warning would have applied to *every* record, though, we know something else is wrong and it raises a fatal error.