### PR TITLE
Fix python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ CacheControl==0.12.0
 chardet==3.0.4
 click==7.1.1
 Flask==1.1.1
-html5lib==1.0.1
+html5lib==1.1.0
 idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 lxml==4.6.5
 MarkupSafe==1.1.1
-python-dateutil==2.8.1
-requests==2.23.0
+python-dateutil==2.8.2
+requests==2.26.0
 selenium==3.141.0
-urllib3==1.25.8
-webdrivermanager==0.8.0
+urllib3==1.26.7
+webdrivermanager==0.10.0
 websocket-client==0.57.0
 Werkzeug==1.0.0


### PR DESCRIPTION
The automation over in stop-covid19-sfbayarea is failing because some of our dependencies don’t work in Python 3.10 (some deprecated features were finally removed). This just updates our dependencies to something that works.